### PR TITLE
feat: add semantic versioning with CI/CD auto-bump and version footer

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,32 @@
+name: Version Bump
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  version-bump:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install standard-version
+        run: npm install --save-dev standard-version
+
+      - name: Bump version
+        run: npx standard-version
+
+      - name: Push changes
+        run: git push && git push --tags

--- a/.planning/PLANS.md
+++ b/.planning/PLANS.md
@@ -1,0 +1,292 @@
+# SemVer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement semantic versioning triggered on PR merge to main, with version displayed in a footer on all pages.
+
+**Architecture:** 
+- Use standard-version with GitHub Actions to auto-bump version on PR merge
+- Generate version file at build time via Vite prebuild script
+- Display version in fixed footer component
+
+**Tech Stack:** Node.js, GitHub Actions, standard-version, Vite
+
+---
+
+### Task 1: Create GitHub Actions workflow
+
+**Files:**
+- Create: `.github/workflows/version-bump.yml`
+
+- [ ] **Step 1: Create workflow directory and file**
+
+```bash
+mkdir -p .github/workflows
+```
+
+```yaml
+name: Version Bump
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  version-bump:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Install standard-version
+        run: npm install --save-dev standard-version
+      
+      - name: Bump version
+        run: npx standard-version
+      
+      - name: Push changes
+        run: git push && git push --tags
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/version-bump.yml
+git commit -m "ci: add version bump workflow on PR merge"
+```
+
+---
+
+### Task 2: Create .versionrc configuration
+
+**Files:**
+- Create: `.versionrc`
+
+- [ ] **Step 1: Write .versionrc file**
+
+```json
+{
+  "types": [
+    { "type": "feat", "release": "minor" },
+    { "type": "fix", "release": "patch" },
+    { "type": "perf", "release": "patch" },
+    { "type": "refactor", "release": "patch" },
+    { "type": "docs", "release": "patch" },
+    { "type": "style", "release": "patch" },
+    { "type": "test", "release": "patch" },
+    { "type": "build", "release": "patch" }
+  ]
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .versionrc
+git commit -m "config: add standard-version configuration"
+```
+
+---
+
+### Task 3: Create version generation script
+
+**Files:**
+- Create: `scripts/generate-version.js`
+
+- [ ] **Step 1: Create scripts directory**
+
+```bash
+mkdir -p scripts
+```
+
+- [ ] **Step 2: Write generate-version.js**
+
+```javascript
+import { writeFileSync } from 'fs';
+import { execSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const packageJsonPath = join(__dirname, '..', 'package.json');
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+
+const version = packageJson.version;
+const date = new Date().toISOString();
+const commit = execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
+
+const content = `// Auto-generated - do not edit
+export const version = '${version}';
+export const buildDate = '${date}';
+export const commit = '${commit}';
+`;
+
+const versionPath = join(__dirname, '..', 'src', 'version.ts');
+writeFileSync(versionPath, content);
+
+console.log(`Generated version: ${version} (${commit})`);
+```
+
+Note: Add `import { readFileSync } from 'fs';` at the top.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/generate-version.js
+git commit -m "build: add version generation script"
+```
+
+---
+
+### Task 4: Update package.json with prebuild script
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Add prebuild script**
+
+Add to scripts:
+```json
+"prebuild": "node scripts/generate-version.js"
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add package.json
+git commit -m "build: add prebuild script for version generation"
+```
+
+---
+
+### Task 5: Create VersionFooter component
+
+**Files:**
+- Create: `src/components/common/VersionFooter.tsx`
+
+- [ ] **Step 1: Create common components directory**
+
+```bash
+mkdir -p src/components/common
+```
+
+- [ ] **Step 2: Write VersionFooter component**
+
+```tsx
+import { Box, Typography } from '@mui/material';
+import { version, commit } from '../../version';
+import { useTranslation } from 'react-i18next';
+
+export const VersionFooter: React.FC = () => {
+  const { t } = useTranslation();
+  
+  return (
+    <Box
+      component="footer"
+      sx={{
+        py: 1,
+        px: 2,
+        textAlign: 'center',
+        borderTop: '1px solid',
+        borderColor: 'divider',
+      }}
+    >
+      <Typography variant="caption" color="text.secondary">
+        v{version}
+        {import.meta.env.DEV && ` • ${commit}`}
+      </Typography>
+    </Box>
+  );
+};
+```
+
+Add `import React from 'react';` at the top.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/common/VersionFooter.tsx
+git commit -m "feat: add VersionFooter component"
+```
+
+---
+
+### Task 6: Add footer to Layout
+
+**Files:**
+- Modify: `src/components/layout/Layout.tsx`
+
+- [ ] **Step 1: Import VersionFooter**
+
+Add import:
+```tsx
+import { VersionFooter } from '../common/VersionFooter';
+```
+
+- [ ] **Step 2: Add footer before closing Box**
+
+Find the closing `</Box>` at the end of the component and add before it:
+```tsx
+          <VersionFooter />
+        </Box>
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/layout/Layout.tsx
+git commit -m "feat: add version footer to all pages"
+```
+
+---
+
+### Task 7: Test the build
+
+**Files:**
+- None (verification)
+
+- [ ] **Step 1: Run build**
+
+```bash
+npm run build
+```
+
+- [ ] **Step 2: Verify version.ts generated**
+
+Check that `src/version.ts` contains the version.
+
+- [ ] **Step 3: Commit all remaining changes**
+
+```bash
+git add .
+git commit -m "feat: complete semver implementation"
+```
+
+---
+
+## Summary
+
+| Task | Description |
+|------|-------------|
+| 1 | GitHub Actions workflow |
+| 2 | .versionrc config |
+| 3 | Version generation script |
+| 4 | package.json prebuild |
+| 5 | VersionFooter component |
+| 6 | Add footer to Layout |
+| 7 | Test build |
+
+**Plan complete.**

--- a/.planning/SPEC.md
+++ b/.planning/SPEC.md
@@ -1,0 +1,181 @@
+# SemVer + Version Display Specification
+
+**Date:** 2026-05-02
+
+## Overview
+
+- Implement semantic versioning triggered on PR merge to main
+- Display version in footer on all pages
+
+## Part 1: CI/CD Version Bump
+
+### Trigger
+
+- GitHub Actions workflow runs on: `pull_request` target `main` with `types: [closed]` AND `mergeable: true`
+- Alternatively: run on `push to main` and check if it's a merge commit
+
+### Tool
+
+Use [standard-version](https://github.com/conventional-changelog/standard-version):
+- Analyzes conventional commits since last release
+- Auto-increments based on commit types:
+  - `fix:` → patch (e.g., 1.0.0 → 1.0.1)
+  - `feat:` → minor (e.g., 1.0.0 → 1.1.0)
+  - `feat!:` or `BREAKING CHANGE:` → major
+
+### Workflow Steps
+
+1. Checkout code
+2. Install Node.js
+3. Install dependencies (`npm ci`)
+4. Run `npx standard-version` (pre-release mode)
+5. If version changed:
+   - Commit version bump
+   - Create git tag (`v{major.minor.patch}`)
+   - Push commit + tag
+6. (Optional) Create GitHub Release
+
+### Configuration
+
+`.versionrc`:
+```json
+{
+  "types": [
+    { "type": "feat", "release": "minor" },
+    { "type": "fix", "release": "patch" },
+    { "type": "perf", "release": "patch" },
+    { "type": "refactor", "release": "patch" },
+    { "type": "docs", "release": "patch" },
+    { "type": "style", "release": "patch" },
+    { "type": "test", "release": "patch" },
+    { "type": "build", "release": "patch" }
+  ]
+}
+```
+
+### GitHub Actions File
+
+`.github/workflows/version-bump.yml`:
+```yaml
+name: Version Bump
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  version-bump:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Bump version
+        run: npx standard-version
+      
+      - name: Push changes
+        run: git push && git push --tags
+```
+
+---
+
+## Part 2: Version Display in Footer
+
+### Approach
+
+Generate version at build-time using Vite's `define` plugin.
+
+### Implementation
+
+1. Add script to `package.json` to generate version file before build:
+   ```json
+   {
+     "scripts": {
+       "prebuild": "node scripts/generate-version.js",
+       "build": "tsc -b && vite build"
+     }
+   }
+   }
+   ```
+
+2. Create `scripts/generate-version.js`:
+   ```javascript
+   import { writeFileSync } from 'fs';
+   import { execSync } from 'child_process';
+   
+   const version = require('./package.json').version;
+   const date = new Date().toISOString();
+   const commit = execSync('git rev-parse --short HEAD').toString().trim();
+   
+   const content = `export const version = '${version}';\nexport const buildDate = '${date}';\nexport const commit = '${commit}';\n`;
+   
+   writeFileSync('src/version.ts', content);
+   ```
+
+3. Create footer component `src/components/common/VersionFooter.tsx`:
+   ```tsx
+   import { version, buildDate, commit } from '../../version';
+   import { useTranslation } from 'react-i18next';
+   
+   export const VersionFooter: React.FC = () => {
+     const { t } = useTranslation();
+     
+     return (
+       <Box
+         component="footer"
+         sx={{
+           py: 1,
+           px: 2,
+           textAlign: 'center',
+           fontSize: '0.75rem',
+           color: 'text.secondary',
+           borderTop: '1px solid',
+           borderColor: 'divider',
+         }}
+       >
+         v{version}
+         {import.meta.env.DEV && ` • ${commit}`}
+       </Box>
+     );
+   };
+   ```
+
+4. Add to Layout component on all pages:
+   - Import `VersionFooter` component
+   - Add before closing `Box` or after `children`
+
+---
+
+## Acceptance Criteria
+
+- [ ] GitHub Actions workflow created in `.github/workflows/`
+- [ ] Version bumps automatically on PR merge to main
+- [ ] Version increment follows conventional commits
+- [ ] Git tag created with version
+- [ ] Footer component created
+- [ ] Footer visible on all pages showing version number
+- [ ] Development build shows commit hash
+
+---
+
+## Files to Create/Modify
+
+| File | Action |
+|------|--------|
+| `.github/workflows/version-bump.yml` | Create |
+| `.versionrc` | Create |
+| `scripts/generate-version.js` | Create |
+| `src/components/common/VersionFooter.tsx` | Create |
+| `src/components/layout/Layout.tsx` | Modify (add footer) |
+| `package.json` | Modify (add prebuild script) |

--- a/.versionrc
+++ b/.versionrc
@@ -1,0 +1,12 @@
+{
+  "types": [
+    { "type": "feat", "release": "minor" },
+    { "type": "fix", "release": "patch" },
+    { "type": "perf", "release": "patch" },
+    { "type": "refactor", "release": "patch" },
+    { "type": "docs", "release": "patch" },
+    { "type": "style", "release": "patch" },
+    { "type": "test", "release": "patch" },
+    { "type": "build", "release": "patch" }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prebuild": "node scripts/generate-version.js",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/scripts/generate-version.js
+++ b/scripts/generate-version.js
@@ -1,0 +1,25 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { execSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const packageJsonPath = join(__dirname, '..', 'package.json');
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+
+const version = packageJson.version;
+const date = new Date().toISOString();
+const commit = execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
+
+const content = `// Auto-generated - do not edit
+export const version = '${version}';
+export const buildDate = '${date}';
+export const commit = '${commit}';
+`;
+
+const versionPath = join(__dirname, '..', 'src', 'version.ts');
+writeFileSync(versionPath, content);
+
+console.log(`Generated version: ${version} (${commit})`);

--- a/src/components/common/VersionFooter.tsx
+++ b/src/components/common/VersionFooter.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import { version, commit } from '../../version';
+
+export const VersionFooter: React.FC = () => {
+  return (
+    <Box
+      component="footer"
+      sx={{
+        py: 1,
+        px: 2,
+        textAlign: 'center',
+        borderTop: '1px solid',
+        borderColor: 'divider',
+      }}
+    >
+      <Typography variant="caption" color="text.secondary">
+        v{version}
+        {import.meta.env.DEV && ` • ${commit}`}
+      </Typography>
+    </Box>
+  );
+};

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -11,6 +11,7 @@ import { useAuthStore } from '../../store/useAuthStore';
 import { useFinanceStore, type Transaction } from '../../store/useFinanceStore';
 import { getEnvVar } from '../../utils/variables.utils';
 import TransactionModal from '../modals/TransactionModal';
+import { VersionFooter } from '../common/VersionFooter';
 
 // Initialize dayjs locale based on current language
 dayjs.locale(i18n.language);
@@ -414,6 +415,7 @@ const Layout: React.FC<{ children: React.ReactNode; pageTitle?: string; pageDesc
         type={modalType}
         transaction={transactionToEdit}
       />
+      <VersionFooter />
     </Box>
   );
 };

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,4 @@
+// Auto-generated - do not edit
+export const version = '2026.2.1';
+export const buildDate = '2026-05-02T19:16:54.781Z';
+export const commit = '839fd4d';


### PR DESCRIPTION
## Summary

- Add semantic versioning triggered on PR merge to main using standard-version
- Display version number in footer on all pages

### CI/CD Version Bump

GitHub Actions workflow (`.github/workflows/version-bump.yml`):
- Runs when PR is merged to main
- Uses [standard-version](https://github.com/conventional-changelog/standard-version) to analyze commit messages
- Auto-increments based on conventional commits:
  - `fix:` → patch (e.g., 1.0.0 → 1.0.1)
  - `feat:` → minor (e.g., 1.0.0 → 1.1.0)
  - `feat!:` or `BREAKING CHANGE:` → major
- Creates git tag with version

### Version Footer

Footer component (`src/components/common/VersionFooter.tsx`):
- Shows version number (e.g., "v2026.2.1")
- In development mode, also shows commit hash (e.g., "v2026.2.1 • 839fd4d")
- Visible on all pages via Layout component

### Build

Version is generated at build time via `scripts/generate-version.js`:
- Reads version from `package.json`
- Gets current git commit hash
- Creates `src/version.ts` for frontend use

### Files Changed

| File | Action |
|------|--------|
| `.github/workflows/version-bump.yml` | Created |
| `.versionrc` | Created |
| `scripts/generate-version.js` | Created |
| `src/components/common/VersionFooter.tsx` | Created |
| `src/components/layout/Layout.tsx` | Modified |
| `package.json` | Modified |