### PR TITLE
[IMP] Better transaction layout (YATF-80)

### DIFF
--- a/docs/YATF/.obsidian/graph.json
+++ b/docs/YATF/.obsidian/graph.json
@@ -17,6 +17,6 @@
   "repelStrength": 10,
   "linkStrength": 1,
   "linkDistance": 250,
-  "scale": 1,
+  "scale": 1.4335271210298899,
   "close": false
 }

--- a/docs/YATF/.obsidian/workspace.json
+++ b/docs/YATF/.obsidian/workspace.json
@@ -11,10 +11,14 @@
             "id": "ee6f90c3afea53ee",
             "type": "leaf",
             "state": {
-              "type": "graph",
-              "state": {},
-              "icon": "lucide-git-fork",
-              "title": "Graph view"
+              "type": "markdown",
+              "state": {
+                "file": "plans/transaction-layout-implementation.md",
+                "mode": "source",
+                "source": false
+              },
+              "icon": "lucide-file",
+              "title": "transaction-layout-implementation"
             }
           }
         ]
@@ -90,6 +94,7 @@
             "state": {
               "type": "backlink",
               "state": {
+                "file": "plans/transaction-layout-implementation.md",
                 "collapseAll": false,
                 "extraContext": false,
                 "sortOrder": "alphabetical",
@@ -99,7 +104,7 @@
                 "unlinkedCollapsed": true
               },
               "icon": "links-coming-in",
-              "title": "Backlinks"
+              "title": "Backlinks for transaction-layout-implementation"
             }
           },
           {
@@ -108,11 +113,12 @@
             "state": {
               "type": "outgoing-link",
               "state": {
+                "file": "plans/transaction-layout-implementation.md",
                 "linksCollapsed": false,
                 "unlinkedCollapsed": true
               },
               "icon": "links-going-out",
-              "title": "Outgoing links"
+              "title": "Outgoing links from transaction-layout-implementation"
             }
           },
           {
@@ -150,12 +156,13 @@
             "state": {
               "type": "outline",
               "state": {
+                "file": "plans/transaction-layout-implementation.md",
                 "followCursor": false,
                 "showSearch": false,
                 "searchQuery": ""
               },
               "icon": "lucide-list",
-              "title": "Outline"
+              "title": "Outline of transaction-layout-implementation"
             }
           }
         ]
@@ -178,6 +185,10 @@
   },
   "active": "ee6f90c3afea53ee",
   "lastOpenFiles": [
+    "features/transaction-layout-improvement.md",
+    "raw/codebase/CONCERNS.md",
+    "plans/transaction-layout-implementation.md",
+    "conventions/branch-strategy.md",
     "index.md"
   ]
 }

--- a/docs/YATF/features/transaction-layout-improvement.md
+++ b/docs/YATF/features/transaction-layout-improvement.md
@@ -1,0 +1,71 @@
+---
+title: "Transaction Layout Improvement"
+tags: [feature, frontend, transactions, planned]
+created: 2026-06-22
+updated: 2026-06-22
+status: planned
+sources: ["https://github.com/AlexDevsTheWeb/myfinance/issues/80"]
+related: ["plans/transaction-layout-implementation", "architecture/tech-stack"]
+---
+
+# Feature: Better Transaction Layout
+
+Status: planned
+Priority: medium
+
+## Description
+
+Improve the `/transactions` route layout: move the Spending by Category chart from the right sidebar into the main content area (under the search form), adopt a clear two-column layout, and make the filter form more compact.
+
+## Requirements
+
+- Two-column layout with left column (4/12) and right column (8/12)
+- Filters card on the left (with category + subcategory on the same row to save vertical space)
+- Spending by Category pie chart placed directly below the filter card in the left column
+- Transaction table remains on the right column (8/12)
+- Header/title spans full width above the two columns
+- No sticky positioning on the chart — natural scroll flow
+- Pie chart sizing adapts to the narrower left column
+
+## Design
+
+### Layout Structure
+
+Breakpoints: stacks on mobile (`xs:12` each), 4/8 split at `md`+ (`md:4` / `md:8`).
+
+```
+[Full width: Title / Header]
+─────────────────────────────────────────────
+|  Left Column (4/12)      |  Right Column (8/12) |
+|  ┌─────────────────┐      |  ┌──────────────────┐ |
+|  │ Filters Card     │      |  │ Transaction Table │ |
+|  │ Search           │      |  │                   │ |
+|  │ From │ To        │      |  │                   │ |
+|  │ Cat  │ Subcat    │      |  │                   │ |
+|  │ [sort buttons]   │      |  └──────────────────┘ |
+|  └─────────────────┘      |                        |
+|  ┌─────────────────┐      |                        |
+|  │ Spending by      │      |                        |
+|  │ Category (Pie)   │      |                        |
+|  └─────────────────┘      |                        |
+─────────────────────────────
+```
+
+### Filter Form Changes
+
+- Category and Subcategory fields move from separate rows to the same row (6 cols each)
+- All other filter fields remain unchanged
+- Pie chart height reduced from 320px to ~280px to fit the narrower column
+
+## Implementation Notes
+
+- Single file change: `src/pages/TransactionsPage.tsx`
+- Uses MUI Grid2 for layout
+- The CategoryPieChart component stays unchanged
+- The CategoryPieChart moves from the outer right column to inside the left filter column, below the filter card
+
+## Related
+
+- [[plans/transaction-layout-implementation]]
+- [[architecture/tech-stack]]
+- [[conventions/coding-conventions]]

--- a/docs/YATF/index.md
+++ b/docs/YATF/index.md
@@ -10,6 +10,7 @@
 | Page | Summary | Sources |
 |------|---------|---------|
 | [[features/car-management-redesign]] | Car page bento grid redesign with monthly averages | [`raw/SPEC.md`](raw/SPEC.md) |
+| [[features/transaction-layout-improvement]] | Two-column transaction layout with filter + chart on left | [#80](https://github.com/AlexDevsTheWeb/myfinance/issues/80) |
 
 ## Plans
 
@@ -17,6 +18,7 @@
 |------|---------|---------|
 | [[plans/roadmap]] | Project roadmap with phases, status, and priorities | [`raw/ROADMAP.md`](raw/ROADMAP.md) |
 | [[plans/car-redesign-implementation]] | Step-by-step implementation plan for car management redesign | [`raw/PLANS.md`](raw/PLANS.md) |
+| [[plans/transaction-layout-implementation]] | Implementation plan for transaction page layout restructure | [#80](https://github.com/AlexDevsTheWeb/myfinance/issues/80) |
 
 ## Architecture
 

--- a/docs/YATF/log.md
+++ b/docs/YATF/log.md
@@ -21,6 +21,11 @@
 - Updated [[conventions/coding-conventions]] to point to the dedicated page
 - Updated CLAUDE.md branch strategy section to reference the wiki
 
+## [2026-06-22] spec | Feature | Transaction Layout Improvement
+- Created [[features/transaction-layout-improvement]] from [#80](https://github.com/AlexDevsTheWeb/myfinance/issues/80)
+- Created [[plans/transaction-layout-implementation]] with step-by-step tasks
+- Updated index.md
+
 ## [2026-06-22] re-map | Codebase | Full mapping via gsd-map-codebase (4 parallel agents)
 - Re-mapped codebase with tech, arch, quality, and concerns focus agents
 - Updated raw files from `.planning/codebase/*.md` → `raw/codebase/*.md`

--- a/docs/YATF/plans/transaction-layout-implementation.md
+++ b/docs/YATF/plans/transaction-layout-implementation.md
@@ -1,0 +1,55 @@
+---
+title: "Transaction Layout Improvement Implementation Plan"
+tags: [plans, implementation, transactions, frontend]
+created: 2026-06-22
+updated: 2026-06-22
+status: planned
+sources: ["https://github.com/AlexDevsTheWeb/myfinance/issues/80"]
+related: ["features/transaction-layout-improvement", "architecture/tech-stack"]
+---
+
+# Plan: Transaction Layout Improvement Implementation
+
+Status: planned
+
+## Goal
+
+Restructure the `/transactions` page into a two-column layout: filter card + pie chart on the left (4/12), transaction table on the right (8/12), with category/subcategory on the same row.
+
+## Architecture
+
+Single-page React component in TransactionsPage.tsx using MUI Grid2.
+
+## Tasks
+
+### Task 1: Restructure Layout
+- Remove the outer Grid container that has the 8/4 split (main + sidebar)
+- Make the header span full width
+- Create a new Grid container with 4/8 left/right split
+- Move the filters into the left column (was inside the 8-col inner grid)
+- Move the pie chart into the left column below the filter card (was in the 4-col sidebar)
+
+### Task 2: Compact Filter Form
+- Change category and subcategory Grid items from `xs:12` each to `xs:12, sm:6` each (same row)
+- Filter card continues to have `borderRadius: 0` and glass background styling
+
+### Task 3: Pie Chart Sizing
+- Remove the sticky positioning (was `position: 'sticky', top: 24`)
+- Reduce chart height from 320px to ~280px to fit the narrower column
+
+### Task 4: Build Verification
+- Run `npm run build`
+- Visual check of layout on different screen sizes
+
+## Dependencies
+
+- [[features/transaction-layout-improvement]]
+- [[conventions/coding-conventions]]
+
+## Verification
+
+- `npm run build` passes
+- Two-column layout renders correctly at md+ breakpoints
+- Category + subcategory on same row
+- Pie chart visible below filter card in left column
+- Transaction table in right column

--- a/src/analytics/components/CategoryPieChart.tsx
+++ b/src/analytics/components/CategoryPieChart.tsx
@@ -13,11 +13,20 @@ interface CategoryPieChartProps {
   title?: string;
 }
 
+const ITEMS_PER_ROW = 2;
+const BASE_HEIGHT = 300;
+const LEGEND_ROW_HEIGHT = 24;
+
 const CategoryPieChart: React.FC<CategoryPieChartProps> = ({ data, title }) => {
   const chartData = data.map(d => ({
     name: d.category,
     value: d.total,
   }));
+
+  const chartHeight = Math.max(
+    BASE_HEIGHT,
+    BASE_HEIGHT + Math.ceil(chartData.length / ITEMS_PER_ROW) * LEGEND_ROW_HEIGHT
+  );
 
   return (
     <Paper sx={{ p: 2 }}>
@@ -26,7 +35,7 @@ const CategoryPieChart: React.FC<CategoryPieChartProps> = ({ data, title }) => {
           {title}
         </Typography>
       )}
-      <Box sx={{ height: 320, width: '100%' }}>
+      <Box sx={{ height: chartHeight, width: '100%' }}>
         <ResponsiveContainer width="100%" height="100%">
           <PieChart>
             <Pie
@@ -53,7 +62,6 @@ const CategoryPieChart: React.FC<CategoryPieChartProps> = ({ data, title }) => {
             />
             <Legend
               verticalAlign="bottom"
-              height={36}
               iconType="circle"
               formatter={(value: string) => (
                 <span style={{ color: 'rgba(255,255,255,0.8)', fontSize: '0.85rem' }}>{value}</span>

--- a/src/pages/TransactionsPage.tsx
+++ b/src/pages/TransactionsPage.tsx
@@ -131,144 +131,138 @@ const TransactionsPage: React.FC = () => {
 
   return (
       <Box sx={{ pb: 6 }}>
+        <Box sx={{ mb: 4 }}>
+          <Typography variant="h4" sx={{ fontWeight: 800, letterSpacing: -1, display: 'flex', alignItems: 'center', gap: 2 }}>
+            <ReceiptLong sx={{ fontSize: 40, color: 'primary.main' }} />
+            Transactions
+          </Typography>
+          <Typography variant="body1" sx={{ opacity: 0.6 }}>
+            Browse and filter your entire transaction history.
+          </Typography>
+        </Box>
+
         <Grid container spacing={3}>
-          <Grid size={{ xs: 12, md: 8 }}>
-            <Box sx={{ mb: 4 }}>
-              <Typography variant="h4" sx={{ fontWeight: 800, letterSpacing: -1, display: 'flex', alignItems: 'center', gap: 2 }}>
-                <ReceiptLong sx={{ fontSize: 40, color: 'primary.main' }} />
-                Transactions
-              </Typography>
-              <Typography variant="body1" sx={{ opacity: 0.6 }}>
-                Browse and filter your entire transaction history.
-              </Typography>
-            </Box>
-
-            <Grid container spacing={2}>
-              <Grid size={{ xs: 12, lg: 4 }}>
-                <Card sx={{ borderRadius: 0, background: 'rgba(30, 41, 59, 0.5)', backdropFilter: 'blur(10px)', border: '1px solid rgba(255, 255, 255, 0.05)' }}>
-                  <CardContent sx={{ py: 2 }}>
-                    <Box sx={{ mb: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                      <Typography variant="h6" sx={{ fontWeight: 600 }}>{t('transactions.filters.title')}</Typography>
-                      <Button size="small" variant="outlined" startIcon={<FilterList />} onClick={handleClearFilters} sx={{ borderRadius: 2 }}>
-                        Clear
-                      </Button>
-                    </Box>
-                    <Grid container spacing={2}>
-                      <Grid size={{ xs: 12 }}>
-                        <TextField
-                          fullWidth
-                          label="Search Description"
-                          variant="outlined"
-                          value={search}
-                          onChange={(e) => setSearch(e.target.value)}
-                          slotProps={{
-                            input: {
-                              startAdornment: (
-                                <InputAdornment position="start">
-                                  <Search sx={{ opacity: 0.5 }} />
-                                </InputAdornment>
-                              ),
-                            },
-                          }}
-                        />
-                      </Grid>
-                      <Grid size={{ xs: 12, sm: 6 }}>
-                        <DatePicker
-                          label="From"
-                          value={startDate}
-                          onChange={(newValue: Dayjs | null) => setStartDate(newValue)}
-                          slotProps={{ textField: { fullWidth: true } }}
-                        />
-                      </Grid>
-                      <Grid size={{ xs: 12, sm: 6 }}>
-                        <DatePicker
-                          label="To"
-                          value={endDate}
-                          onChange={(newValue: Dayjs | null) => setEndDate(newValue)}
-                          slotProps={{ textField: { fullWidth: true } }}
-                        />
-                      </Grid>
-                      <Grid size={{ xs: 12 }}>
-                        <FormControl fullWidth>
-                          <InputLabel>{t('transactions.filters.category')}</InputLabel>
-                          <Select
-                            value={category}
-                            label={t('transactions.filters.category')}
-                            onChange={(e) => {
-                              setCategory(e.target.value);
-                              setSubcategory('all');
-                            }}
-                          >
-                            <MenuItem value="all">{t('transactions.filters.allCategories')}</MenuItem>
-                            {allCategories.map(cat => (
-                              <MenuItem key={cat} value={cat}>{cat}</MenuItem>
-                            ))}
-                          </Select>
-                        </FormControl>
-                      </Grid>
-                      <Grid size={{ xs: 12 }}>
-                        <FormControl fullWidth disabled={category === 'all'}>
-                          <InputLabel>{t('transactions.filters.subcategory')}</InputLabel>
-                          <Select
-                            value={subcategory}
-                            label={t('transactions.filters.subcategory')}
-                            onChange={(e) => setSubcategory(e.target.value)}
-                          >
-                            <MenuItem value="all">{t('transactions.filters.allSubcategories')}</MenuItem>
-                            {availableSubcategories.map(sub => (
-                              <MenuItem key={sub} value={sub}>{sub}</MenuItem>
-                            ))}
-                          </Select>
-                        </FormControl>
-                      </Grid>
-                      <Grid size={{ xs: 12 }}>
-                        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center' }}>
-                          <Typography variant="body2" sx={{ mr: 1, opacity: 0.5 }}>{t('transactions.filters.sortBy')}</Typography>
-                          {[
-                            { val: 'date-desc', label: 'Date', icon: <ArrowDownward sx={{ fontSize: 16 }} /> },
-                            { val: 'date-asc', label: 'Date', icon: <ArrowUpward sx={{ fontSize: 16 }} /> },
-                            { val: 'amount-desc', label: 'Amount', icon: <ArrowDownward sx={{ fontSize: 16 }} /> },
-                            { val: 'amount-asc', label: 'Amount', icon: <ArrowUpward sx={{ fontSize: 16 }} /> },
-                          ].map((s) => (
-                            <Button
-                              key={s.val}
-                              size="small"
-                              variant={sortBy === s.val ? 'contained' : 'outlined'}
-                              onClick={() => setSortBy(s.val)}
-                              startIcon={s.icon}
-                              sx={{ borderRadius: 4, textTransform: 'none' }}
-                            >
-                              {s.label}
-                            </Button>
-                          ))}
-                        </Box>
-                      </Grid>
-                    </Grid>
-                  </CardContent>
-                </Card>
-              </Grid>
-
-              <Grid size={{ xs: 12, lg: 8 }}>
-                <TransactionTable 
-                  onEdit={handleEditTransaction} 
-                  customData={paginatedTransactions} 
-                  limit={'no'} 
-                  count={filteredTransactions.length}
-                  page={page}
-                  rowsPerPage={rowsPerPage}
-                  onPageChange={(_, newPage) => setPage(newPage)}
-                />
-              </Grid>
-            </Grid>
-          </Grid>
-
           <Grid size={{ xs: 12, md: 4 }}>
-            <Box sx={{ position: 'sticky', top: 24 }}>
+            <Card sx={{ borderRadius: 0, background: 'rgba(30, 41, 59, 0.5)', backdropFilter: 'blur(10px)', border: '1px solid rgba(255, 255, 255, 0.05)' }}>
+              <CardContent sx={{ py: 2 }}>
+                <Box sx={{ mb: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <Typography variant="h6" sx={{ fontWeight: 600 }}>{t('transactions.filters.title')}</Typography>
+                  <Button size="small" variant="outlined" startIcon={<FilterList />} onClick={handleClearFilters} sx={{ borderRadius: 2 }}>
+                    Clear
+                  </Button>
+                </Box>
+                <Grid container spacing={2}>
+                  <Grid size={{ xs: 12 }}>
+                    <TextField
+                      fullWidth
+                      label="Search Description"
+                      variant="outlined"
+                      value={search}
+                      onChange={(e) => setSearch(e.target.value)}
+                      slotProps={{
+                        input: {
+                          startAdornment: (
+                            <InputAdornment position="start">
+                              <Search sx={{ opacity: 0.5 }} />
+                            </InputAdornment>
+                          ),
+                        },
+                      }}
+                    />
+                  </Grid>
+                  <Grid size={{ xs: 12, sm: 6 }}>
+                    <DatePicker
+                      label="From"
+                      value={startDate}
+                      onChange={(newValue: Dayjs | null) => setStartDate(newValue)}
+                      slotProps={{ textField: { fullWidth: true } }}
+                    />
+                  </Grid>
+                  <Grid size={{ xs: 12, sm: 6 }}>
+                    <DatePicker
+                      label="To"
+                      value={endDate}
+                      onChange={(newValue: Dayjs | null) => setEndDate(newValue)}
+                      slotProps={{ textField: { fullWidth: true } }}
+                    />
+                  </Grid>
+                  <Grid size={{ xs: 12, sm: 6 }}>
+                    <FormControl fullWidth>
+                      <InputLabel>{t('transactions.filters.category')}</InputLabel>
+                      <Select
+                        value={category}
+                        label={t('transactions.filters.category')}
+                        onChange={(e) => {
+                          setCategory(e.target.value);
+                          setSubcategory('all');
+                        }}
+                      >
+                        <MenuItem value="all">{t('transactions.filters.allCategories')}</MenuItem>
+                        {allCategories.map(cat => (
+                          <MenuItem key={cat} value={cat}>{cat}</MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  </Grid>
+                  <Grid size={{ xs: 12, sm: 6 }}>
+                    <FormControl fullWidth disabled={category === 'all'}>
+                      <InputLabel>{t('transactions.filters.subcategory')}</InputLabel>
+                      <Select
+                        value={subcategory}
+                        label={t('transactions.filters.subcategory')}
+                        onChange={(e) => setSubcategory(e.target.value)}
+                      >
+                        <MenuItem value="all">{t('transactions.filters.allSubcategories')}</MenuItem>
+                        {availableSubcategories.map(sub => (
+                          <MenuItem key={sub} value={sub}>{sub}</MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  </Grid>
+                  <Grid size={{ xs: 12 }}>
+                    <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center' }}>
+                      <Typography variant="body2" sx={{ mr: 1, opacity: 0.5 }}>{t('transactions.filters.sortBy')}</Typography>
+                      {[
+                        { val: 'date-desc', label: 'Date', icon: <ArrowDownward sx={{ fontSize: 16 }} /> },
+                        { val: 'date-asc', label: 'Date', icon: <ArrowUpward sx={{ fontSize: 16 }} /> },
+                        { val: 'amount-desc', label: 'Amount', icon: <ArrowDownward sx={{ fontSize: 16 }} /> },
+                        { val: 'amount-asc', label: 'Amount', icon: <ArrowUpward sx={{ fontSize: 16 }} /> },
+                      ].map((s) => (
+                        <Button
+                          key={s.val}
+                          size="small"
+                          variant={sortBy === s.val ? 'contained' : 'outlined'}
+                          onClick={() => setSortBy(s.val)}
+                          startIcon={s.icon}
+                          sx={{ borderRadius: 4, textTransform: 'none' }}
+                        >
+                          {s.label}
+                        </Button>
+                      ))}
+                    </Box>
+                  </Grid>
+                </Grid>
+              </CardContent>
+            </Card>
+
+            <Box sx={{ mt: 3 }}>
               <CategoryPieChart
                 data={spendingData.breakdown}
                 title="Spending by Category"
               />
             </Box>
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 8 }}>
+            <TransactionTable
+              onEdit={handleEditTransaction}
+              customData={paginatedTransactions}
+              limit={'no'}
+              count={filteredTransactions.length}
+              page={page}
+              rowsPerPage={rowsPerPage}
+              onPageChange={(_, newPage) => setPage(newPage)}
+            />
           </Grid>
         </Grid>
 


### PR DESCRIPTION
## Summary

Restructures the `/transactions` page into a clean two-column layout (4/8 split).

## Changes

- **Layout**: Header spans full width; left column (md:4) has filter card + Spending by Category pie chart; right column (md:8) has transaction table
- **Form**: Category and subcategory now on the same row — less vertical space
- **Chart**: Dynamic height calculation to prevent legend clipping regardless of category count

## Commits

- docs: add design spec for transaction layout improvement (YATF-80)
- feat: restructure transactions page into two-column layout (YATF-80)
- fix: make pie chart height dynamic to prevent legend clipping (YATF-80)
- chore: update Obsidian workspace state (YATF-80)

Closes #80