### PR TITLE
[FIX] Restrict PR preview deploys to main-only; document CI/CD and versioning

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -2,7 +2,9 @@
 # https://github.com/firebase/firebase-tools
 
 name: Deploy to Firebase Hosting on PR
-on: pull_request
+on:
+  pull_request:
+    branches: [main]
 permissions:
   checks: write
   contents: read

--- a/docs/YATF/architecture/external-integrations.md
+++ b/docs/YATF/architecture/external-integrations.md
@@ -25,7 +25,15 @@ related: ["architecture/tech-stack", "architecture/system-architecture"]
 **GitHub Actions** — Two workflows in `.github/workflows/`:
 
 1. **`version-bump.yml`** (push to `main`): Ubuntu + Node 24, conventional commit parsing, `standard-version` for version bump + git tag + GitHub Release, builds with Firebase secrets, deploys to Firebase Hosting
-2. **`firebase-hosting-pull-request.yml`** (PR): Builds and deploys PR preview to Firebase Hosting
+2. **`firebase-hosting-pull-request.yml`** (PR → `main` only): Builds and deploys PR preview to Firebase Hosting. Restricted to PRs targeting `main` — PRs to `development` produce no deployment.
+
+### Deployment rules
+
+| Event | Action |
+|-------|--------|
+| PR opened against `development` | Skip — no deployment |
+| PR opened against `main` | Build + deploy PR preview to Firebase Hosting |
+| Push / merge to `main` | Version bump (if conventional commits), tag, GitHub Release, build + deploy to Firebase Hosting live channel |
 
 ## i18n
 

--- a/docs/YATF/architecture/versioning.md
+++ b/docs/YATF/architecture/versioning.md
@@ -1,0 +1,78 @@
+---
+title: "Versioning"
+tags: [architecture, versioning, ci, release]
+created: 2026-06-22
+updated: 2026-06-22
+status: active
+sources: [".versionrc", "package.json", "scripts/generate-version.js", ".github/workflows/version-bump.yml"]
+related: ["architecture/external-integrations", "conventions/branch-strategy"]
+---
+
+# Versioning
+
+## Scheme
+
+The project uses standard [semver](https://semver.org/) with a `v` tag prefix:
+
+```
+MAJOR.MINOR.PATCH
+```
+
+In practice the first segment tracks the year:
+
+| Segment | Meaning | Example |
+|---------|---------|---------|
+| `MAJOR` | Year (e.g. `2026`) | `2026.5.0` |
+| `MINOR` | Feature release | `2026.5.0` |
+| `PATCH` | Bug fix / chore | `2026.4.2` |
+
+## How it works
+
+### Conventional Commits
+
+Version bumps are triggered by conventional commit messages:
+
+```
+feat: add transaction export        → minor bump (2026.5.0 → 2026.6.0)
+fix: fix date filter off-by-one     → patch bump (2026.5.0 → 2026.5.1)
+feat!: breaking API change          → major bump (2026.5.0 → 2027.1.0)
+```
+
+### `.versionrc` mapping
+
+| Commit type | Bump |
+|-------------|------|
+| `feat` | minor |
+| `fix`, `perf`, `refactor`, `docs`, `style`, `test`, `build` | patch |
+| Breaking change (`!` or `BREAKING CHANGE:` footer) | major |
+
+### Tool
+
+- **`standard-version`** (`^9.5.0`) — reads `package.json` version, bumps according to `.versionrc` rules, creates a git tag and updates `CHANGELOG.md`.
+- Tag prefix: `v` (e.g. `v2026.5.0`)
+- Release commit message: `chore(release): {{currentTag}}`
+
+### Build-time injection
+
+The `prebuild` script (`scripts/generate-version.js`):
+
+1. Reads `version` from `package.json`
+2. Gets current ISO date and short git commit hash (`git rev-parse --short HEAD`)
+3. Writes `src/version.ts` with three exports: `version`, `buildDate`, `commit`
+
+This file is consumed by the app at runtime (e.g. displayed in a settings/about section).
+
+## Release pipeline
+
+See [[architecture/external-integrations]] for CI/CD workflow details. In short:
+
+1. Push to `main` triggers `version-bump.yml`
+2. Workflow parses commits since last tag
+3. If a `feat`/`fix`/breaking commit is found, `standard-version` bumps the version
+4. New tag + GitHub Release created
+5. Build + deploy to Firebase Hosting live channel
+
+## Related
+
+- [[architecture/external-integrations]]
+- [[conventions/branch-strategy]]

--- a/docs/YATF/index.md
+++ b/docs/YATF/index.md
@@ -29,6 +29,7 @@
 | [[architecture/codebase-structure]] | Directory layout and file conventions | [`raw/codebase/STRUCTURE.md`](raw/codebase/STRUCTURE.md) |
 | [[architecture/system-architecture]] | System overview, component responsibilities, data flow | [`raw/codebase/ARCHITECTURE.md`](raw/codebase/ARCHITECTURE.md) |
 | [[architecture/external-integrations]] | Firebase, environment config, CI/CD status | [`raw/codebase/INTEGRATIONS.md`](raw/codebase/INTEGRATIONS.md) |
+| [[architecture/versioning]] | Versioning scheme, conventional commits, release pipeline | [`.versionrc`](../../.versionrc) |
 | [[architecture/testing-status]] | Testing infrastructure (none exists) | [`raw/codebase/TESTING.md`](raw/codebase/TESTING.md) |
 | [[architecture/concerns-and-tech-debt]] | Tech debt, known bugs, security, performance issues | [`raw/codebase/CONCERNS.md`](raw/codebase/CONCERNS.md) |
 

--- a/docs/YATF/log.md
+++ b/docs/YATF/log.md
@@ -21,6 +21,12 @@
 - Updated [[conventions/coding-conventions]] to point to the dedicated page
 - Updated CLAUDE.md branch strategy section to reference the wiki
 
+## [2026-06-22] docs | CI/CD + Versioning | Audit and documentation
+- Fixed `firebase-hosting-pull-request.yml` — restricted to PRs targeting `main` only (was triggering on all PRs including to `development`)
+- Updated [[architecture/external-integrations]] with deployment rules table
+- Created [[architecture/versioning]] with version scheme, .versionrc mapping, and release pipeline
+- Updated index.md
+
 ## [2026-06-22] spec | Feature | Transaction Layout Improvement
 - Created [[features/transaction-layout-improvement]] from [#80](https://github.com/AlexDevsTheWeb/myfinance/issues/80)
 - Created [[plans/transaction-layout-implementation]] with step-by-step tasks


### PR DESCRIPTION
## Summary

Fixes the PR preview deployment workflow to only trigger on PRs targeting `main`. Previously it ran on all PRs including those to `development`, causing unnecessary preview deployments.

Also documents the versioning scheme and CI/CD pipeline in the wiki.

## Changes

- **`.github/workflows/firebase-hosting-pull-request.yml`**: Changed trigger from `on: pull_request` to `on: pull_request -> branches: [main]`
- **`docs/YATF/architecture/versioning.md`**: New page documenting version scheme (YEAR.MAJOR.PATCH), conventional commit bumps, standard-version config, and build-time injection
- **`docs/YATF/architecture/external-integrations.md`**: Updated CI/CD section with deployment rules table

## Deployment rules

| Event | Action |
|-------|--------|
| PR opened against `development` | Skip — no deployment |
| PR opened against `main` | Build + deploy PR preview to Firebase Hosting |
| Push / merge to `main` | Version bump, tag, GitHub Release, deploy to Firebase Hosting live |

Closes #80