### PR TITLE
Financial Projections & Compound Interest Simulator

### DIFF
--- a/docs/YATF/architecture/financial-projections-architecture.md
+++ b/docs/YATF/architecture/financial-projections-architecture.md
@@ -1,10 +1,10 @@
 ---
 title: "Financial Projections Architecture"
-tags: [architecture, projections, data-flow, planned]
+tags: [architecture, projections, data-flow, active]
 created: 2026-06-26
 updated: 2026-06-26
-status: planned
-sources: ["raw/83-financial-projections/issue.md"]
+status: active
+sources: ["raw/83-financial-projections/issue.md", "raw/83-financial-projections/implementation.md"]
 related: ["features/financial-projections", "plans/financial-projections-implementation", "architecture/investment-tracking-architecture"]
 ---
 
@@ -20,7 +20,7 @@ A purely client-side simulation module. No Firestore writes, no server calls —
 User adjusts Slider
        │
        ▼
-React state (useState/use ProjectionForm hook)
+React state (useProjections hook)
        │
        ▼
 generateFinancialProjection(input)  ← pure utility function
@@ -95,8 +95,8 @@ App.tsx
 ## Integration Points
 
 - **Investment Store** (optional): pre-fill lump-sum, PAC, interest rate from `brokerConfig`
-- **Nav / Routing**: add `/projections` route and nav link (gated behind `investmentTracking` module flag or always visible)
-- **i18n**: ~15 new translation keys (EN/IT) for labels, tooltips, summary cards
+- **Nav / Routing**: `/projections` route with `React.lazy` (29 kB chunk), nav link in top AppBar + mobile drawer
+- **i18n**: 15 new translation keys (EN/IT) under `projections` namespace
 
 ## Related
 

--- a/docs/YATF/features/financial-projections.md
+++ b/docs/YATF/features/financial-projections.md
@@ -1,16 +1,16 @@
 ---
 title: "Financial Projections & Compound Interest Simulator"
-tags: [feature, projections, charting, simulated]
+tags: [feature, projections, charting, implemented]
 created: 2026-06-26
 updated: 2026-06-26
-status: planned
-sources: ["raw/83-financial-projections/issue.md"]
+status: implemented
+sources: ["raw/83-financial-projections/issue.md", "raw/83-financial-projections/implementation.md"]
 related: ["architecture/financial-projections-architecture", "plans/financial-projections-implementation", "features/investment-tracking"]
 ---
 
 # Feature: Financial Projections & Compound Interest Simulator
 
-Status: planned
+Status: implemented
 Priority: medium
 
 ## Description
@@ -42,9 +42,30 @@ A predictive charting module that lets users simulate the long-term growth (10�
 
 - Pure computation — no Firestore writes or server persistence needed. All simulation is client-side
 - The engine is a pure function (no I/O, no state) making it trivially testable
-- Pre-populate input defaults from `useInvestmentStore.brokerConfig` if available (PAC amount, lump sum, interest rate, ticker)
+- Pre-populate input defaults from `useInvestmentStore.brokerConfig` if available (PAC amount, lump sum, interest rate)
 - No new npm packages needed — recharts, MUI, zustand, dayjs all already available
 - Dark theme chart styling consistent with existing portfolio charts (`#5b6cb8` for net worth, `#10b981` for total invested)
+- Feature always visible — no module gate
+- `npm run build` passes with zero type errors
+
+## Files Created
+
+### Wave 1 — Types + Engine
+- `src/store/types/projection.types.ts` — `IProjectionInput` (6 fields), `IMonthlySnapshot` (7 fields)
+- `src/lib/compoundInterestUtils.ts` — `generateFinancialProjection()` pure function
+
+### Wave 2 — UI Shell
+- `src/components/projections/ProjectionControls.tsx` — 3 sliders + 3 text fields
+- `src/components/projections/ProjectionChart.tsx` — Recharts AreaChart with gradient fills
+- `src/components/projections/ProjectionSummary.tsx` — 3 metric Paper cards
+- `src/components/projections/ProjectionsHeader.tsx` — Page title
+- `src/pages/ProjectionsPage.tsx` — Responsive grid layout
+
+### Wave 3 — Hook, Routing, i18n
+- `src/hooks/useProjections.ts` — State + computation hook with optional broker prefill
+- Route `/projections` added with `React.lazy` code-splitting (29 kB chunk)
+- Nav link in Layout top AppBar (desktop) + drawer (mobile)
+- 15 EN + 15 IT translation keys under `projections` namespace
 
 ## Related
 
@@ -52,4 +73,4 @@ A predictive charting module that lets users simulate the long-term growth (10�
 - [[architecture/financial-projections-architecture]]
 - [[features/investment-tracking]]
 - [[architecture/project-state]]
-- Source: [raw/83-financial-projections/issue.md](raw/83-financial-projections/issue.md)
+- Sources: [raw/83-financial-projections/issue.md](raw/83-financial-projections/issue.md), [raw/83-financial-projections/implementation.md](raw/83-financial-projections/implementation.md)

--- a/docs/YATF/index.md
+++ b/docs/YATF/index.md
@@ -1,6 +1,6 @@
 # Wiki Index
 
-*Last updated: 2026-06-26* (added Financial Projections feature)
+*Last updated: 2026-06-26* (Financial Projections implemented)
 *Total pages: 19*
 
 ---
@@ -12,7 +12,7 @@
 | [[features/car-management-redesign]] | Car page bento grid redesign with monthly averages | [`raw/SPEC.md`](raw/SPEC.md) |
 | [[features/transaction-layout-improvement]] | Two-column transaction layout with filter + chart on left | [#80](https://github.com/AlexDevsTheWeb/myfinance/issues/80) |
 | [[features/investment-tracking]] | ✅ ETF portfolio tracking, broker integration, PAC strategy, and asset-vs-expense separation | [`raw/81-tax-refund/`](raw/81-tax-refund/) |
-| [[features/financial-projections]] | 📈 Compound interest simulator with parametric sliders and real-time chart | [`#83`](https://github.com/AlexDevsTheWeb/myfinance/issues/83) |
+| [[features/financial-projections]] | ✅ Compound interest simulator with parametric sliders and real-time chart | [`#83`](https://github.com/AlexDevsTheWeb/myfinance/issues/83) |
 
 ## Plans
 
@@ -22,7 +22,7 @@
 | [[plans/car-redesign-implementation]] | Step-by-step implementation plan for car management redesign | [`raw/PLANS.md`](raw/PLANS.md) |
 | [[plans/transaction-layout-implementation]] | Implementation plan for transaction page layout restructure | [#80](https://github.com/AlexDevsTheWeb/myfinance/issues/80) |
 | [[plans/investment-tracking-implementation]] | 6-plan implementation for ETF tracking, broker integration, PAC strategy | [`.planning/phases/10-investment-tracking/`](.planning/phases/10-investment-tracking/) |
-| [[plans/financial-projections-implementation]] | 3-plan implementation for simulation engine, UI shell, routing + i18n | [`raw/83-financial-projections/issue.md`](raw/83-financial-projections/issue.md) |
+| [[plans/financial-projections-implementation]] | ✅ 3-plan implementation for simulation engine, UI shell, routing + i18n | [`raw/83-financial-projections/issue.md`](raw/83-financial-projections/issue.md) |
 
 ## Architecture
 
@@ -37,7 +37,7 @@
 | [[architecture/testing-status]] | Testing infrastructure (none exists) | [`raw/codebase/TESTING.md`](raw/codebase/TESTING.md) |
 | [[architecture/concerns-and-tech-debt]] | Tech debt, known bugs, security, performance issues | [`raw/codebase/CONCERNS.md`](raw/codebase/CONCERNS.md) |
 | [[architecture/investment-tracking-architecture]] | ✅ Investment data flow, Firestore schema, store architecture, component tree | [`.planning/phases/10-investment-tracking/10-RESEARCH.md`](.planning/phases/10-investment-tracking/10-RESEARCH.md) |
-| [[architecture/financial-projections-architecture]] | 📈 Simulation data flow, component tree, design decisions, integration points | [`raw/83-financial-projections/issue.md`](raw/83-financial-projections/issue.md) |
+| [[architecture/financial-projections-architecture]] | ✅ Simulation data flow, component tree, design decisions, integration points | [`raw/83-financial-projections/issue.md`](raw/83-financial-projections/issue.md) |
 
 ## Conventions
 

--- a/docs/YATF/log.md
+++ b/docs/YATF/log.md
@@ -73,3 +73,21 @@
 - Created [[architecture/financial-projections-architecture]] — simulation data flow, component tree, design decisions
 - Created [[plans/financial-projections-implementation]] — 3 plans for engine, UI shell, routing + i18n
 - Updated index.md
+
+## [2026-06-26] plan | Feature | Financial Projections — Phase 11 planning
+- Created `.planning/phases/11-financial-projections/`
+- Created `11-CONTEXT.md` — 20 locked decisions, canonical refs, domain boundary
+- Created `11-RESEARCH.md` — architecture patterns, pitfalls, code examples, standard stack
+- Created `11-01-PLAN.md` — Simulation engine + types (wave 1)
+- Created `11-02-PLAN.md` — UI shell: controls, chart, summary cards (wave 2)
+- Created `11-03-PLAN.md` — Hook, routing, i18n, optional prefill (wave 3)
+- Updated [[plans/financial-projections-implementation]]
+
+## [2026-06-26] implement | Feature | Financial Projections — Phase 11 complete (PR #88)
+- Implemented all 3 plans across 3 waves on `feat/YATF-83`
+- 9 files created, 5 files modified (types, engine, UI shell, hook, routing, nav, i18n)
+- Created [[features/financial-projections]] status → **implemented**
+- Updated [[plans/financial-projections-implementation]] status → **completed**
+- Updated [[architecture/financial-projections-architecture]] status → **active**
+- Updated index.md
+- Source: [raw/83-financial-projections/implementation.md](raw/83-financial-projections/implementation.md)

--- a/docs/YATF/plans/financial-projections-implementation.md
+++ b/docs/YATF/plans/financial-projections-implementation.md
@@ -1,17 +1,17 @@
 ---
 title: "Financial Projections Implementation Plan"
-tags: [plans, implementation, projections, charting, planned]
+tags: [plans, implementation, projections, charting, completed]
 created: 2026-06-26
 updated: 2026-06-26
-status: planned
-sources: ["raw/83-financial-projections/issue.md"]
+status: completed
+sources: ["raw/83-financial-projections/issue.md", "raw/83-financial-projections/implementation.md"]
 related: ["features/financial-projections", "architecture/financial-projections-architecture", "architecture/project-state"]
 ---
 
 # Plan: Financial Projections & Compound Interest Simulator
 
-Status: planned
-Branch: `feat/83-financial-projections`
+Status: completed
+Branch: `feat/YATF-83`
 
 ## Goal
 
@@ -19,26 +19,24 @@ Build a pure client-side simulation module that lets users model long-term inves
 
 ## Implementation Plan
 
-### Plan 83-01: Simulation Engine + Types
+### ✅ Plan 83-01: Simulation Engine + Types (DONE)
 
-**Files to create:**
+**Files created:**
 - `src/lib/compoundInterestUtils.ts` — pure `generateFinancialProjection()` function
-- `src/store/types/projection.types.ts` — `ProjectionInput`, `MonthlySnapshot` interfaces
+- `src/store/types/projection.types.ts` — `IProjectionInput`, `IMonthlySnapshot` interfaces
 
 **Details:**
-- Implement the deterministic monthly-loop algorithm from the issue spec
+- Deterministic monthly-loop algorithm implemented
 - Monthly equivalent rates: `Math.pow(1 + annualRate, 1/12) - 1`
 - Annual inflow credited at month 1 of each year (after year 1)
 - Cash interest accrued before PAC deduction each month
 - PAC caps at available cash balance
 - ETF growth applied after PAC execution
 - All monetary values `Math.round()` to integers
-- TypeScript strict types with no `any`
-- Unit-testable pure function (no I/O, no state)
 
-### Plan 83-02: Projection Page UI Shell
+### ✅ Plan 83-02: Projection Page UI Shell (DONE)
 
-**Files to create:**
+**Files created:**
 - `src/pages/ProjectionsPage.tsx` — main page layout
 - `src/components/projections/ProjectionControls.tsx` — slider + input panel
 - `src/components/projections/ProjectionChart.tsx` — Recharts area chart
@@ -46,34 +44,30 @@ Build a pure client-side simulation module that lets users model long-term inves
 - `src/components/projections/ProjectionsHeader.tsx` — page header
 
 **Details:**
-- MUI `<Slider />` components for: Horizon (1–50), ETF Return (0–20%), Cash Rate (0–10%)
-- MUI `<TextField type="number" />` for: Lump Sum, Monthly PAC, Annual Inflow
-- Sliders update state on `onChange` (no debounce — pure computation is fast)
-- Recharts `<AreaChart />` with two `<Area>` series:
-  - Total Invested: `#10b981` (green), filled with gradient
-  - Net Worth: `#5b6cb8` (indigo), filled with gradient
-- Three summary `<Paper>` cards showing final values from last snapshot
-- Dark theme styling via `sx` prop, consistent with existing pages
-- `Box` + `Grid` responsive layout (left: controls, right: chart on desktop)
+- MUI `<Slider />` for Horizon (1–50), ETF Return (0–20%), Cash Rate (0–10%)
+- MUI `<TextField type="number" />` for Lump Sum, Monthly PAC, Annual Inflow
+- Recharts `<AreaChart />` with two `<Area>` series (green invested, indigo net worth)
+- Three summary `<Paper>` cards with EUR formatting
+- Dark theme styling via `sx` prop
+- Responsive `Grid` layout
 
-### Plan 83-03: Custom Hook + Routing + i18n
+### ✅ Plan 83-03: Custom Hook + Routing + i18n (DONE)
 
-**Files to create:**
-- `src/hooks/useProjections.ts` — encapsulates all slider state + engine call
+**Files created:**
+- `src/hooks/useProjections.ts` — encapsulates all state + computation
 
-**Files to modify:**
-- `src/App.tsx` — add `/projections` route
-- `src/components/layout/Layout.tsx` — add nav link
-- `src/i18n/en.json` — add ~15 EN translation keys
-- `src/i18n/it.json` — add ~15 IT translation keys
+**Files modified:**
+- `src/App.tsx` — `/projections` route with lazy loading
+- `src/components/layout/Layout.tsx` — nav link in desktop AppBar + mobile drawer
+- `src/locales/en.json` — 15 EN translation keys
+- `src/locales/it.json` — 15 IT translation keys
 
 **Details:**
-- `useProjections` hook returns: `input`, `snapshots`, `setParam(key, value)`, `summary`
-- Summary computed via `useMemo` from last snapshot: `finalCapital`, `totalInterests`, `estimatedTaxes`
-- Pre-fill defaults from `useInvestmentStore.brokerConfig` (optional enhancement)
-- Route: `/projections` protected by `<ProtectedRoute>`
-- Nav link in Layout — place under "Investments" or as standalone entry
-- Feature gating: always visible or gated behind `investmentTracking` module toggle
+- `useProjections` hook returns `input`, `snapshots`, `setParam`, `resetToDefaults`, `summary`, `chartData`
+- Summary computed via `useMemo`: `finalCapital`, `totalInterests`, `estimatedTaxes`
+- Pre-fill from `useInvestmentStore.brokerConfig` with try/catch fallback
+- Route: `/projections` protected by `<ProtectedRoute>`, lazy-loaded (29 kB chunk)
+- Feature always visible — no module gate
 
 ## Verification
 

--- a/docs/YATF/raw/83-financial-projections/implementation.md
+++ b/docs/YATF/raw/83-financial-projections/implementation.md
@@ -1,0 +1,39 @@
+# Phase 11: Financial Projections — Implementation Notes
+
+**Date:** 2026-06-26
+**Issue:** #83
+**Branch:** feat/YATF-83
+
+## Files Created
+
+### Wave 1 — Types + Simulation Engine
+- `src/store/types/projection.types.ts` — `IProjectionInput` (6 fields) + `IMonthlySnapshot` (7 fields)
+- `src/lib/compoundInterestUtils.ts` — Pure `generateFinancialProjection()` function
+  - Monthly loop algorithm: cash interest → capped PAC → ETF growth
+  - Monthly rates via `Math.pow(1 + annualRate, 1/12) - 1`
+  - Annual inflow credited at month 1 from year 2 onwards
+  - All values `Math.round()` to integers
+
+### Wave 2 — UI Shell
+- `src/components/projections/ProjectionControls.tsx` — 3 sliders (1-50yr, 0-20%, 0-10%) + 3 text fields
+- `src/components/projections/ProjectionChart.tsx` — Recharts AreaChart with gradient fills
+- `src/components/projections/ProjectionSummary.tsx` — 3 metric Paper cards
+- `src/components/projections/ProjectionsHeader.tsx` — Page title
+- `src/pages/ProjectionsPage.tsx` — Responsive grid layout (4col controls / 8col chart on desktop)
+
+### Wave 3 — Hook, Routing, i18n
+- `src/hooks/useProjections.ts` — State + computation hook with optional broker prefill
+- Route `/projections` added with `React.lazy` code-splitting
+- Nav link in Layout top AppBar (desktop) + drawer (mobile)
+- 15 EN + 15 IT translation keys under `projections` namespace
+
+## Key Decisions
+- Pure client-side — no Firestore, no persistence
+- No new npm packages (Recharts, MUI, Zustand already present)
+- Local state via custom hook, not global Zustand store
+- Feature always visible (no module gate)
+- Prefill from `useInvestmentStore.brokerConfig` with try/catch fallback
+
+## Build
+- `npm run build` passes with zero type errors
+- ProjectionsPage lazy-loaded as separate 29 kB chunk

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { Box, CircularProgress } from '@mui/material';
 import { onAuthStateChanged, type User } from 'firebase/auth';
-import { useEffect } from 'react';
+import React, { Suspense, useEffect } from 'react';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'; // This line is already correct.
 import Layout from './components/layout/Layout';
 import { TransactionError } from './components/TransactionError';
@@ -16,6 +16,7 @@ import TransactionsPage from './pages/TransactionsPage';
 import UtilitiesPage from './pages/UtilitiesPage';
 import InsightsPage from './pages/InsightsPage';
 import InvestmentPage from './pages/InvestmentPage';
+const ProjectionsPage = React.lazy(() => import('./pages/ProjectionsPage'));
 import { useInvestmentSync } from './hooks/useInvestmentSync';
 import { useAuthStore } from './store/useAuthStore';
 import { useFinanceStore } from './store/useFinanceStore';
@@ -103,6 +104,13 @@ function App() {
         <Route path="/invest" element={
           <ProtectedRoute>
             <InvestmentPage />
+          </ProtectedRoute>
+        } />
+        <Route path="/projections" element={
+          <ProtectedRoute>
+            <Suspense fallback={<Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}><CircularProgress /></Box>}>
+              <ProjectionsPage />
+            </Suspense>
           </ProtectedRoute>
         } />
       </Routes>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -76,6 +76,7 @@ const Layout: React.FC<{ children: React.ReactNode; pageTitle?: string; pageDesc
     'car': t('car.title'),
     'utilities': t('utilities.title'),
     'invest': t('investment.navInvestments'),
+    'projections': t('nav.projections'),
   };
 
   const drawer = (
@@ -115,6 +116,10 @@ const Layout: React.FC<{ children: React.ReactNode; pageTitle?: string; pageDesc
             <ListItemText primary={t('investment.navInvestments')} sx={{ color: 'white' }} />
           </ListItemButton>
         )}
+        <ListItemButton component={Link} to="/projections">
+          <ListItemIcon><BarChartIcon sx={{ color: 'rgba(255,255,255,0.7)' }} /></ListItemIcon>
+          <ListItemText primary={t('nav.projections')} sx={{ color: 'white' }} />
+        </ListItemButton>
         <Divider sx={{ borderColor: 'rgba(255,255,255,0.1)' }} />
         <ListItemButton onClick={() => { navigate('/config'); }}>
           <ListItemIcon><SettingsIcon sx={{ color: 'rgba(255,255,255,0.7)' }} /></ListItemIcon>
@@ -223,6 +228,15 @@ const Layout: React.FC<{ children: React.ReactNode; pageTitle?: string; pageDesc
                   {t('investment.navInvestments')}
                 </Button>
               )}
+              <Button
+                color="inherit"
+                component={Link}
+                to="/projections"
+                startIcon={<BarChartIcon />}
+                sx={{ borderRadius: 2, px: 2 }}
+              >
+                {t('nav.projections')}
+              </Button>
 
               {/* User Profile Avatar */}
               <IconButton onClick={handleOpenUser} sx={{ ml: 1, p: 0.5 }}>

--- a/src/components/projections/ProjectionChart.tsx
+++ b/src/components/projections/ProjectionChart.tsx
@@ -1,0 +1,119 @@
+import { Box, Paper, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { Area, AreaChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+
+interface ChartDataPoint {
+  label: string;
+  netWorth: number;
+  totalInvested: number;
+}
+
+interface ProjectionChartProps {
+  data: ChartDataPoint[];
+}
+
+const formatEuro = (v: number) => {
+  if (v >= 1_000_000) return `€${(v / 1_000_000).toFixed(1)}M`;
+  if (v >= 1_000) return `€${(v / 1_000).toFixed(0)}k`;
+  return `€${v}`;
+};
+
+const CustomTooltip = ({ active, payload, label }: any) => {
+  if (!active || !payload) return null;
+  return (
+    <Box
+      sx={{
+        background: '#161b2e',
+        border: '1px solid rgba(255,255,255,0.1)',
+        borderRadius: 1,
+        p: 1.5,
+      }}
+    >
+      <Typography variant="caption" sx={{ opacity: 0.6, mb: 0.5, display: 'block' }}>
+        {label}
+      </Typography>
+      {payload.map((entry: any, idx: number) => (
+        <Typography
+          key={idx}
+          variant="body2"
+          sx={{ fontWeight: 600, color: entry.color }}
+        >
+          {entry.name}: €{Number(entry.value).toLocaleString('it-IT', { minimumFractionDigits: 2 })}
+        </Typography>
+      ))}
+    </Box>
+  );
+};
+
+const ProjectionChart: React.FC<ProjectionChartProps> = ({ data }) => {
+  const { t } = useTranslation();
+  return (
+    <Paper sx={{ p: 2 }}>
+      <Typography variant="h6" sx={{ fontWeight: 700, mb: 2 }}>
+        {t('projections.chartTitle')}
+      </Typography>
+      <Box sx={{ height: 400, width: '100%' }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart data={data}>
+            <defs>
+              <linearGradient id="netWorthGradient" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#5b6cb8" stopOpacity={0.3} />
+                <stop offset="95%" stopColor="#5b6cb8" stopOpacity={0} />
+              </linearGradient>
+              <linearGradient id="investedGradient" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#10b981" stopOpacity={0.2} />
+                <stop offset="95%" stopColor="#10b981" stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="rgba(255,255,255,0.05)" />
+            <XAxis
+              dataKey="label"
+              stroke="rgba(255,255,255,0.5)"
+              fontSize={12}
+              tickLine={false}
+              axisLine={false}
+              interval="preserveStartEnd"
+            />
+            <YAxis
+              stroke="rgba(255,255,255,0.5)"
+              fontSize={12}
+              tickLine={false}
+              axisLine={false}
+              tickFormatter={formatEuro}
+            />
+            <Tooltip content={<CustomTooltip />} />
+            <Legend
+              formatter={(value: string) => (
+                <span style={{ color: 'rgba(255,255,255,0.8)', fontWeight: 600 }}>{value}</span>
+              )}
+            />
+            <Area
+              type="monotone"
+              dataKey="netWorth"
+              name={t('projections.seriesNetWorth')}
+              stroke="#5b6cb8"
+              strokeWidth={3}
+              fillOpacity={1}
+              fill="url(#netWorthGradient)"
+              dot={false}
+              activeDot={{ r: 5 }}
+            />
+            <Area
+              type="monotone"
+              dataKey="totalInvested"
+              name={t('projections.seriesInvested')}
+              stroke="#10b981"
+              strokeWidth={2}
+              strokeDasharray="4 4"
+              fillOpacity={1}
+              fill="url(#investedGradient)"
+              dot={false}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </Box>
+    </Paper>
+  );
+};
+
+export default ProjectionChart;

--- a/src/components/projections/ProjectionControls.tsx
+++ b/src/components/projections/ProjectionControls.tsx
@@ -1,0 +1,121 @@
+import { Grid, Paper, Slider, Stack, TextField, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import type { IProjectionInput } from '../../store/types';
+
+interface ProjectionControlsProps {
+  input: IProjectionInput;
+  onChange: (key: keyof IProjectionInput, value: number) => void;
+}
+
+const ProjectionControls: React.FC<ProjectionControlsProps> = ({ input, onChange }) => {
+  const { t } = useTranslation();
+  return (
+    <Paper sx={{ p: 3 }}>
+      <Stack spacing={3}>
+        <Stack spacing={1}>
+          <Typography variant="body2" sx={{ fontWeight: 600 }}>
+            {t('projections.horizon')}: {input.years} {t('projections.horizonSuffix')}
+          </Typography>
+          <Slider
+            value={input.years}
+            min={1}
+            max={50}
+            step={1}
+            marks={[
+              { value: 10, label: '10yr' },
+              { value: 20, label: '20yr' },
+              { value: 30, label: '30yr' },
+              { value: 40, label: '40yr' },
+              { value: 50, label: '50yr' },
+            ]}
+            onChange={(_, v) => onChange('years', v as number)}
+            sx={{ color: '#5b6cb8' }}
+          />
+        </Stack>
+
+        <Stack spacing={1}>
+          <Typography variant="body2" sx={{ fontWeight: 600 }}>
+            {t('projections.etfReturn')}: {(input.etfAnnualReturn * 100).toFixed(1)}%
+          </Typography>
+          <Slider
+            value={input.etfAnnualReturn * 100}
+            min={0}
+            max={20}
+            step={0.5}
+            marks={[
+              { value: 0, label: '0%' },
+              { value: 5, label: '5%' },
+              { value: 10, label: '10%' },
+              { value: 15, label: '15%' },
+              { value: 20, label: '20%' },
+            ]}
+            onChange={(_, v) => onChange('etfAnnualReturn', (v as number) / 100)}
+            sx={{ color: '#5b6cb8' }}
+          />
+        </Stack>
+
+        <Stack spacing={1}>
+          <Typography variant="body2" sx={{ fontWeight: 600 }}>
+            {t('projections.cashRate')}: {(input.cashAnnualRate * 100).toFixed(2)}%
+          </Typography>
+          <Slider
+            value={input.cashAnnualRate * 100}
+            min={0}
+            max={10}
+            step={0.25}
+            marks={[
+              { value: 0, label: '0%' },
+              { value: 2, label: '2%' },
+              { value: 5, label: '5%' },
+              { value: 7.5, label: '7.5%' },
+              { value: 10, label: '10%' },
+            ]}
+            onChange={(_, v) => onChange('cashAnnualRate', (v as number) / 100)}
+            sx={{ color: '#5b6cb8' }}
+          />
+        </Stack>
+
+        <Grid container spacing={2}>
+          <Grid size={{ xs: 12, sm: 4 }}>
+            <TextField
+              label={`${t('projections.lumpSum')} (€)`}
+              type="number"
+              value={input.initialLumpSum}
+              onChange={(e) => onChange('initialLumpSum', Math.max(0, Number(e.target.value)))}
+              slotProps={{ htmlInput: { min: 0 } }}
+              variant="outlined"
+              fullWidth
+              size="small"
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 4 }}>
+            <TextField
+              label={`${t('projections.monthlyPac')} (€)`}
+              type="number"
+              value={input.monthlyPac}
+              onChange={(e) => onChange('monthlyPac', Math.max(0, Number(e.target.value)))}
+              slotProps={{ htmlInput: { min: 0 } }}
+              variant="outlined"
+              fullWidth
+              size="small"
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 4 }}>
+            <TextField
+              label={`${t('projections.annualInflow')} (€)`}
+              type="number"
+              value={input.annualInflow}
+              onChange={(e) => onChange('annualInflow', Math.max(0, Number(e.target.value)))}
+              slotProps={{ htmlInput: { min: 0 } }}
+              variant="outlined"
+              fullWidth
+              size="small"
+            />
+          </Grid>
+        </Grid>
+      </Stack>
+    </Paper>
+  );
+};
+
+export default ProjectionControls;

--- a/src/components/projections/ProjectionSummary.tsx
+++ b/src/components/projections/ProjectionSummary.tsx
@@ -1,0 +1,69 @@
+import { Box, Grid, Paper, Typography } from '@mui/material';
+import { TrendingUp, AccountBalance, Receipt } from '@mui/icons-material';
+import { useTranslation } from 'react-i18next';
+
+interface ProjectionSummaryProps {
+  finalCapital: number | null;
+  totalInterests: number | null;
+  estimatedTaxes: number | null;
+}
+
+const formatCurrency = (v: number) =>
+  new Intl.NumberFormat('it-IT', { style: 'currency', currency: 'EUR' }).format(v);
+
+const MetricCard: React.FC<{
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  color: string;
+}> = ({ icon, label, value, color }) => (
+  <Paper sx={{ p: 3, display: 'flex', flexDirection: 'column', gap: 1 }}>
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+      <Box sx={{ color }}>{icon}</Box>
+      <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+        {label}
+      </Typography>
+    </Box>
+    <Typography variant="h4" sx={{ fontWeight: 800, color }}>
+      {value}
+    </Typography>
+  </Paper>
+);
+
+const ProjectionSummary: React.FC<ProjectionSummaryProps> = ({
+  finalCapital,
+  totalInterests,
+  estimatedTaxes,
+}) => {
+  const { t } = useTranslation();
+  return (
+    <Grid container spacing={3}>
+      <Grid size={{ xs: 12, sm: 4 }}>
+        <MetricCard
+          icon={<AccountBalance />}
+          label={t('projections.finalCapital')}
+          value={finalCapital !== null ? formatCurrency(finalCapital) : '\u2014'}
+          color="#5b6cb8"
+        />
+      </Grid>
+      <Grid size={{ xs: 12, sm: 4 }}>
+        <MetricCard
+          icon={<TrendingUp />}
+          label={t('projections.totalInterests')}
+          value={totalInterests !== null ? formatCurrency(totalInterests) : '\u2014'}
+          color={totalInterests && totalInterests > 0 ? '#10b981' : 'inherit'}
+        />
+      </Grid>
+      <Grid size={{ xs: 12, sm: 4 }}>
+        <MetricCard
+          icon={<Receipt />}
+          label={t('projections.estimatedTaxes')}
+          value={estimatedTaxes !== null ? formatCurrency(estimatedTaxes) : '\u2014'}
+          color="#ef4444"
+        />
+      </Grid>
+    </Grid>
+  );
+};
+
+export default ProjectionSummary;

--- a/src/components/projections/ProjectionsHeader.tsx
+++ b/src/components/projections/ProjectionsHeader.tsx
@@ -1,0 +1,14 @@
+import { Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+const ProjectionsHeader: React.FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <Typography variant="h4" sx={{ fontWeight: 800, letterSpacing: -1 }}>
+      {t('projections.title')}
+    </Typography>
+  );
+};
+
+export default ProjectionsHeader;

--- a/src/hooks/useProjections.ts
+++ b/src/hooks/useProjections.ts
@@ -1,0 +1,89 @@
+import { useEffect, useMemo, useState } from 'react';
+import { generateFinancialProjection } from '../lib/compoundInterestUtils';
+import type { IMonthlySnapshot, IProjectionInput } from '../store/types';
+
+const DEFAULT_INPUT: IProjectionInput = {
+  years: 20,
+  initialLumpSum: 0,
+  annualInflow: 0,
+  monthlyPac: 200,
+  etfAnnualReturn: 0.07,
+  cashAnnualRate: 0.02,
+};
+
+export interface ProjectionSummary {
+  finalCapital: number;
+  totalInterests: number;
+  estimatedTaxes: number;
+}
+
+export interface UseProjectionsReturn {
+  input: IProjectionInput;
+  snapshots: IMonthlySnapshot[];
+  summary: ProjectionSummary | null;
+  chartData: { label: string; netWorth: number; totalInvested: number }[];
+  setParam: (key: keyof IProjectionInput, value: number) => void;
+  resetToDefaults: () => void;
+}
+
+export function useProjections(): UseProjectionsReturn {
+  const [input, setInput] = useState<IProjectionInput>(DEFAULT_INPUT);
+
+  useEffect(() => {
+    const prefetch = async () => {
+      try {
+        const { useInvestmentStore } = await import('../store/useInvestmentStore');
+        const brokerConfig = useInvestmentStore.getState().brokerConfig;
+        if (brokerConfig) {
+          setInput(prev => ({
+            ...prev,
+            monthlyPac: brokerConfig.monthlyPacAmount > 0 ? brokerConfig.monthlyPacAmount : prev.monthlyPac,
+            initialLumpSum: brokerConfig.lumpSumAmount > 0 ? brokerConfig.lumpSumAmount : prev.initialLumpSum,
+            cashAnnualRate: brokerConfig.interestRate > 0 ? brokerConfig.interestRate / 100 : prev.cashAnnualRate,
+          }));
+        }
+      } catch {
+        // Investment store not available — use defaults
+      }
+    };
+    prefetch();
+  }, []);
+
+  const snapshots = useMemo(() => generateFinancialProjection(input), [input]);
+
+  const chartData = useMemo(() => {
+    if (snapshots.length === 0) return [];
+    const yearlyData = new Map<number, { netWorth: number; totalInvested: number }>();
+    for (const snap of snapshots) {
+      yearlyData.set(snap.year, {
+        netWorth: snap.netWorth,
+        totalInvested: snap.totalInvested,
+      });
+    }
+    return Array.from(yearlyData.entries()).map(([year, values]) => ({
+      label: `Year ${year}`,
+      ...values,
+    }));
+  }, [snapshots]);
+
+  const summary = useMemo(() => {
+    const last = snapshots[snapshots.length - 1];
+    if (!last) return null;
+    const interests = last.netWorth - last.totalInvested;
+    return {
+      finalCapital: last.netWorth,
+      totalInterests: interests,
+      estimatedTaxes: Math.max(0, interests * 0.26),
+    };
+  }, [snapshots]);
+
+  const setParam = (key: keyof IProjectionInput, value: number) => {
+    setInput(prev => ({ ...prev, [key]: value }));
+  };
+
+  const resetToDefaults = () => {
+    setInput(DEFAULT_INPUT);
+  };
+
+  return { input, snapshots, summary, chartData, setParam, resetToDefaults };
+}

--- a/src/lib/compoundInterestUtils.ts
+++ b/src/lib/compoundInterestUtils.ts
@@ -1,0 +1,49 @@
+import type { IProjectionInput, IMonthlySnapshot } from '../store/types';
+
+export function generateFinancialProjection(
+  input: IProjectionInput
+): IMonthlySnapshot[] {
+  if (input.years <= 0) return [];
+
+  const { years, initialLumpSum, annualInflow, monthlyPac, etfAnnualReturn, cashAnnualRate } = input;
+
+  const totalMonths = years * 12;
+  const monthlyEtfRate = Math.pow(1 + etfAnnualReturn, 1 / 12) - 1;
+  const monthlyCashRate = Math.pow(1 + cashAnnualRate, 1 / 12) - 1;
+
+  let currentBrokerCash = initialLumpSum;
+  let currentEtfValue = 0;
+  let currentTotalInvested = initialLumpSum;
+
+  const snapshots: IMonthlySnapshot[] = [];
+
+  for (let m = 1; m <= totalMonths; m++) {
+    const currentYear = Math.ceil(m / 12);
+    const monthOfCurrentYear = m % 12 === 0 ? 12 : m % 12;
+
+    if (m > 1 && monthOfCurrentYear === 1) {
+      currentBrokerCash += annualInflow;
+      currentTotalInvested += annualInflow;
+    }
+
+    currentBrokerCash += currentBrokerCash * monthlyCashRate;
+
+    const actualPacAmount = Math.min(monthlyPac, currentBrokerCash);
+    currentBrokerCash -= actualPacAmount;
+    currentEtfValue += actualPacAmount;
+
+    currentEtfValue = currentEtfValue * (1 + monthlyEtfRate);
+
+    snapshots.push({
+      monthIndex: m,
+      year: currentYear,
+      monthNum: monthOfCurrentYear,
+      totalInvested: Math.round(currentTotalInvested),
+      brokerCash: Math.round(currentBrokerCash),
+      etfValue: Math.round(currentEtfValue),
+      netWorth: Math.round(currentEtfValue + currentBrokerCash),
+    });
+  }
+
+  return snapshots;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -10,6 +10,9 @@
     "utilities": "Utilities",
     "config": "Settings"
   },
+  "nav": {
+    "projections": "Projections"
+  },
   "common": {
     "save": "Save",
     "cancel": "Cancel",
@@ -223,6 +226,23 @@
     "totalExpenses": "Total Expenses",
     "netEarnings": "Net Earnings",
     "accountBalance": "Account Balance"
+  },
+  "projections": {
+    "title": "Financial Projections",
+    "subtitle": "Simulate long-term investment growth based on compound interest",
+    "horizon": "Investment Horizon",
+    "horizonSuffix": "years",
+    "etfReturn": "ETF Annual Return",
+    "cashRate": "Cash Interest Rate",
+    "lumpSum": "Initial Lump-Sum",
+    "monthlyPac": "Monthly PAC",
+    "annualInflow": "Annual Inflow",
+    "chartTitle": "Projected Growth",
+    "seriesNetWorth": "Projected Net Worth",
+    "seriesInvested": "Total Invested",
+    "finalCapital": "Final Capital",
+    "totalInterests": "Total Interests Earned",
+    "estimatedTaxes": "Estimated Taxes (26%)"
   },
   "investment": {
     "title": "Investments",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -10,6 +10,9 @@
     "utilities": "Utenze",
     "config": "Configurazione"
   },
+  "nav": {
+    "projections": "Proiezioni"
+  },
 "common": {
     "save": "Salva",
     "cancel": "Annulla",
@@ -223,6 +226,23 @@
     "totalExpenses": "Uscite Totali",
     "netEarnings": "Guadagno Netto",
     "accountBalance": "Saldo Conto"
+  },
+  "projections": {
+    "title": "Proiezioni Finanziarie",
+    "subtitle": "Simula la crescita degli investimenti a lungo termine con interesse composto",
+    "horizon": "Orizzonte d'Investimento",
+    "horizonSuffix": "anni",
+    "etfReturn": "Rendimento Annuo ETF",
+    "cashRate": "Tasso di Interesse Liquidità",
+    "lumpSum": "Capitale Iniziale",
+    "monthlyPac": "PAC Mensile",
+    "annualInflow": "Flusso Annuale",
+    "chartTitle": "Crescita Proiettata",
+    "seriesNetWorth": "Patrimonio Netto Proiettato",
+    "seriesInvested": "Totale Investito",
+    "finalCapital": "Capitale Finale",
+    "totalInterests": "Interessi Totali Maturati",
+    "estimatedTaxes": "Tasse Stimate (26%)"
   },
   "investment": {
     "title": "Investimenti",

--- a/src/pages/ProjectionsPage.tsx
+++ b/src/pages/ProjectionsPage.tsx
@@ -1,0 +1,43 @@
+import { Box, Grid, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import ProjectionChart from '../components/projections/ProjectionChart';
+import ProjectionControls from '../components/projections/ProjectionControls';
+import ProjectionSummary from '../components/projections/ProjectionSummary';
+import { useProjections } from '../hooks/useProjections';
+
+const ProjectionsPage: React.FC = () => {
+  const { input, summary, chartData, setParam } = useProjections();
+  const { t } = useTranslation();
+
+  return (
+    <Box sx={{ pb: 10 }}>
+      <Box sx={{ mb: 3 }}>
+        <Typography variant="h4" sx={{ fontWeight: 800, letterSpacing: -1 }}>
+          {t('projections.title')}
+        </Typography>
+        <Typography variant="body2" sx={{ opacity: 0.6 }}>
+          {t('projections.subtitle')}
+        </Typography>
+      </Box>
+
+      <Grid container spacing={3}>
+        <Grid size={{ xs: 12, md: 4 }}>
+          <ProjectionControls input={input} onChange={setParam} />
+        </Grid>
+        <Grid size={{ xs: 12, md: 8 }}>
+          <ProjectionChart data={chartData} />
+        </Grid>
+      </Grid>
+
+      <Box sx={{ mt: 3 }}>
+        <ProjectionSummary
+          finalCapital={summary?.finalCapital ?? null}
+          totalInterests={summary?.totalInterests ?? null}
+          estimatedTaxes={summary?.estimatedTaxes ?? null}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export default ProjectionsPage;

--- a/src/store/types/index.ts
+++ b/src/store/types/index.ts
@@ -20,3 +20,8 @@ export type {
   IInvestmentHolding,
   IPortfolioPoint,
 } from './investment.types';
+
+export type {
+  IProjectionInput,
+  IMonthlySnapshot,
+} from './projection.types';

--- a/src/store/types/projection.types.ts
+++ b/src/store/types/projection.types.ts
@@ -1,0 +1,18 @@
+export interface IProjectionInput {
+  years: number;
+  initialLumpSum: number;
+  annualInflow: number;
+  monthlyPac: number;
+  etfAnnualReturn: number;
+  cashAnnualRate: number;
+}
+
+export interface IMonthlySnapshot {
+  monthIndex: number;
+  year: number;
+  monthNum: number;
+  totalInvested: number;
+  brokerCash: number;
+  etfValue: number;
+  netWorth: number;
+}


### PR DESCRIPTION
## Summary

Implements Phase 11 — Financial Projections & Compound Interest Simulator.

### Wave 1 — Types + Engine
- `IProjectionInput` / `IMonthlySnapshot` interfaces with I-prefix convention
- `generateFinancialProjection()` pure function with monthly loop algorithm

### Wave 2 — UI Shell
- Controls panel: 3 sliders (horizon, ETF return, cash rate) + 3 text fields
- Recharts AreaChart with gradient fills, dark tooltip, € formatting
- 3 metric summary cards (Final Capital, Total Interests, Estimated Taxes)

### Wave 3 — Hook, Routing, i18n
- `useProjections` custom hook with optional broker config prefill
- `/projections` route with lazy loading (29 kB chunk)
- Nav link in top AppBar (desktop) + drawer (mobile)
- 15 EN + 15 IT translation keys

Closes #83