### PR TITLE
[YATF-100] Budget & Savings Rate Engine V4 — Full /budget module

### DIFF
--- a/docs/YATF/.obsidian/workspace.json
+++ b/docs/YATF/.obsidian/workspace.json
@@ -11,10 +11,14 @@
             "id": "d83c4f0840b094ae",
             "type": "leaf",
             "state": {
-              "type": "graph",
-              "state": {},
-              "icon": "lucide-git-fork",
-              "title": "Graph view"
+              "type": "markdown",
+              "state": {
+                "file": "features/guida-investimenti.md",
+                "mode": "source",
+                "source": false
+              },
+              "icon": "lucide-file",
+              "title": "guida-investimenti"
             }
           }
         ]
@@ -178,13 +182,18 @@
   },
   "active": "d83c4f0840b094ae",
   "lastOpenFiles": [
-    "plans/investment-tracking-v3-implementation.md",
-    "features/investment-tracking-v3.md",
+    "plans/budget-savings-engine-implementation.md",
+    "features/budget-savings-architecture.md",
+    "features/budget-savings-engine.md",
+    "raw/100-budget-savings-engine/issue.md",
+    "raw/100-budget-savings-engine",
     "raw/98-investment-tracking-v3/issue.md",
     "raw/98-investment-tracking-v3",
+    "plans/investment-tracking-v3-implementation.md",
+    "features/investment-tracking-v3.md",
+    "features/investment-tracking-guide.md",
     "features/historical-snapshots.md",
     "features/guida-investimenti.md",
-    "features/investment-tracking-guide.md",
     "index.md",
     "raw/12-investment-tracking-v2/implementation.md",
     "raw/12-investment-tracking-v2",

--- a/docs/YATF/architecture/financial-projections-architecture.md
+++ b/docs/YATF/architecture/financial-projections-architecture.md
@@ -98,9 +98,24 @@ App.tsx
 - **Nav / Routing**: `/projections` route with `React.lazy` (29 kB chunk), nav link in top AppBar + mobile drawer
 - **i18n**: 15 new translation keys (EN/IT) under `projections` namespace
 
+## Integration with Budget & Savings Rate Engine
+
+The upcoming [[features/budget-savings-engine]] can feed the projections simulator:
+
+| Budget Feature | Projections Integration |
+|----------------|------------------------|
+| Real savings rate | Replace manual income/expense assumptions with actual savings rate from budget engine |
+| Historical rate trend | Prefill projection CAGR-like inputs from computed historical savings rate |
+| Budget surplus projection | Show "what if" scenarios: save X% more → investment growth impact |
+
+See [[plans/budget-savings-engine-implementation#wave-6]] for the savings rate → investment bridge.
+
 ## Related
 
+- [[features/budget-savings-engine]] — Budget module (savings rate data source)
+- [[features/budget-savings-architecture]] — Budget architecture
 - [[features/financial-projections]]
 - [[plans/financial-projections-implementation]]
+- [[plans/budget-savings-engine-implementation]]
 - [[architecture/investment-tracking-architecture]]
 - [[architecture/tech-stack]]

--- a/docs/YATF/architecture/investment-tracking-architecture.md
+++ b/docs/YATF/architecture/investment-tracking-architecture.md
@@ -172,8 +172,23 @@ See [[plans/investment-tracking-v3-implementation]] for the detailed implementat
 | [[features/tax-inflation-modeling]] | Independent — pure projection computation |
 | [[features/ticker-validation]] | Validation at broker config save time |
 
+## Integration with Budget & Savings Rate Engine
+
+The upcoming [[features/budget-savings-engine]] bridges operational budgets with the investment pipeline:
+
+| Budget Feature | Integration Point |
+|----------------|------------------|
+| Savings rate surplus | Surplus (income − expenses) displayed on `/budget` as "available for investment" |
+| Suggested PAC increase | Surplus × 0.5 → prefill suggestion on `/invest` |
+| Investment bridge card | Quick-action button: "Apply to Investment" on BudgetPage |
+| Cash flow impact | Expense budget breaches → reduced investment capacity — surfaced in SavingsRateGauge |
+
+See [[plans/budget-savings-engine-implementation#wave-6]] for detail on the investment bridge.
+
 ## Related
 
+- [[features/budget-savings-engine]] — Budget module (investment pipeline bridge)
+- [[features/budget-savings-architecture]] — Budget architecture
 - [[features/investment-tracking]]
 - [[features/investment-tracking-guide]]
 - [[features/multi-broker-architecture]]
@@ -185,5 +200,6 @@ See [[plans/investment-tracking-v3-implementation]] for the detailed implementat
 - [[plans/investment-tracking-implementation]]
 - [[plans/investment-tracking-v2-enhancements]]
 - [[plans/investment-tracking-v3-implementation]]
+- [[plans/budget-savings-engine-implementation]]
 - [[architecture/system-architecture]]
 - [[architecture/tech-stack]]

--- a/docs/YATF/features/budget-savings-architecture.md
+++ b/docs/YATF/features/budget-savings-architecture.md
@@ -3,7 +3,7 @@ title: "Budget & Savings Rate Architecture"
 tags: [architecture, budget, savings, data-flow, planned]
 created: 2026-06-28
 updated: 2026-06-28
-status: draft
+status: active
 sources: ["raw/100-budget-savings-engine/issue.md"]
 related: ["features/budget-savings-engine", "features/investment-tracking", "features/financial-projections", "architecture/investment-tracking-architecture", "architecture/financial-projections-architecture", "architecture/system-architecture"]
 ---

--- a/docs/YATF/features/budget-savings-architecture.md
+++ b/docs/YATF/features/budget-savings-architecture.md
@@ -1,0 +1,208 @@
+---
+title: "Budget & Savings Rate Architecture"
+tags: [architecture, budget, savings, data-flow, planned]
+created: 2026-06-28
+updated: 2026-06-28
+status: draft
+sources: ["raw/100-budget-savings-engine/issue.md"]
+related: ["features/budget-savings-engine", "features/investment-tracking", "features/financial-projections", "architecture/investment-tracking-architecture", "architecture/financial-projections-architecture", "architecture/system-architecture"]
+---
+
+# Architecture: Budget & Savings Rate Engine
+
+## Overview
+
+The Budget & Savings Rate module adds a new domain to the existing MyFinance ecosystem. It follows the same architectural patterns as the investment tracking module — a standalone Zustand store (`useBudgetStore`), Firestore array fields on the user document, and Recharts for visualization.
+
+Unlike the investment module, budget **progress** is computed client-side from existing `transactions[]` data — no new subcollections or complex sync needed. Budget **configs** (targets, periods) are the only persisted data.
+
+## Data Flow
+
+```
+User sets Budget Target
+        │
+        ▼
+useBudgetStore (Zustand)
+        │
+        ├──► budgetTargets[] state + Firestore write
+        │
+User views Budget Page
+        │
+        ▼
+BudgetEngine (pure computation utility)
+        │
+        ├──► Reads: transactions[] (from useFinanceStore)
+        │         budgetTargets (from useBudgetStore)
+        │         date range (from UI selector)
+        │
+        ├──► Computes: BudgetProgressSnapshot[]
+        │         per category: { targetAmount, actualSpent, percentage, remaining }
+        │         per period:   { totalBudget, totalSpent, savingsRate, surplus }
+        │
+        ▼
+Recharts Visualizations
+    ├── BulletChart (progress per category)
+    ├── ComparisonBar (target vs actual)
+    ├── BurnUpLine (cumulative trajectory)
+    └── SavingsGauge (rate gauge)
+```
+
+## Firestore Schema
+
+Budget configs follow the existing pattern — array field on the `users/{userId}` document:
+
+```typescript
+interface UserDoc {
+  // ... existing fields
+  
+  budgetTargets: BudgetTarget[];     // NEW
+}
+
+interface BudgetTarget {
+  id: string;                        // uuid
+  category: string;                  // matches ICategory.name (expense categories only)
+  period: 'monthly' | 'semiannual' | 'annual';
+  targetAmount: number;              // in EUR
+  color: string;                     // hex color for charts
+  name?: string;                     // optional override (defaults to category name)
+  createdAt: string;                 // ISO date
+  updatedAt: string;
+}
+```
+
+### BudgetProgressSnapshot (computed, not persisted)
+
+```typescript
+interface BudgetProgressSnapshot {
+  category: string;
+  targetAmount: number;
+  actualSpent: number;
+  percentage: number;                // 0–100+
+  remaining: number;                 // targetAmount − actualSpent
+  status: 'safe' | 'warning' | 'breach';
+  periodStart: string;
+  periodEnd: string;
+}
+```
+
+**Why not persist progress?** Budget progress is ephemeral — it changes as new transactions are added. Persisting it would require recomputation trigger hooks. Computing from canonical `transactions[]` on render is simpler and always consistent.
+
+## Store Architecture
+
+**`useBudgetStore.ts`** (new standalone Zustand store):
+
+- **State:** `budgetTargets: BudgetTarget[]`, `isSaving`, `saveError`
+- **CRUD actions:** `addBudgetTarget`, `updateBudgetTarget`, `deleteBudgetTarget` — each follows the optimistic-update → Firestore write pattern identical to `useFinanceStore` and `useInvestmentStore`
+- **No progress state in store** — computed on the fly by the budget engine
+
+**`useBudgetSync.ts`** (new sync hook):
+
+- `onSnapshot` subscription to user document, reads `budgetTargets[]`
+- Initializes from `getDefaultUserConfig()` in `sync/index.ts`
+- Same pattern as `useSyncFinance` and `useInvestmentSync`
+
+## Budget Engine (Computation Layer)
+
+A pure utility function (no side effects, trivially testable):
+
+```typescript
+function computeBudgetProgress(
+  transactions: ITransaction[],
+  budgetTargets: BudgetTarget[],
+  dateRange: { start: string; end: string }
+): {
+  snapshots: BudgetProgressSnapshot[];
+  totals: {
+    totalBudget: number;
+    totalSpent: number;
+    savingsRate: number;     // (income − expenses) / income
+    surplus: number;         // totalBudget − totalSpent
+  };
+  periodSummary: PeriodSummary;
+}
+```
+
+Placed in `src/lib/budgetEngine.ts` — parallel to `compoundInterestUtils.ts`.
+
+### Savings Rate Computation
+
+```
+SavingsRate = (TotalIncome − TotalExpenses) / TotalIncome
+
+Where:
+  TotalIncome   = sum of income transactions in date range
+  TotalExpenses = sum of expense transactions in date range (all categories)
+  SavingsRate   = decimal, displayed as percentage (e.g. 0.25 → "25%")
+```
+
+The savings rate is a **cross-domain metric** — it reads from the finance store's `transactions[]` and feeds into investment planning (surplus → suggested PAC).
+
+## Component Tree
+
+```
+App.tsx
+  └── Layout.tsx
+        └── BudgetPage.tsx (route: /budget)
+              ├── PeriodSelector (month/semiannual/year picker)
+              ├── SavingsRateGauge.tsx (circular or linear gauge)
+              │     └── Current rate vs target rate, with diff indicator
+              │
+              ├── BudgetSummaryCards
+              │     ├── Total Budgeted
+              │     ├── Total Spent
+              │     ├── Remaining
+              │     └── Savings Rate %
+              │
+              ├── BudgetCategoryList
+              │     └── BudgetCategoryCard (one per target)
+              │           ├── BulletChart (progress bar with zones)
+              │           └── Quick stats (spent / target / remaining)
+              │
+              ├── ComparisonBarChart (Target vs Actual — Recharts BarChart)
+              │
+              ├── BurnUpLineChart (Cumulative spend vs ideal — Recharts AreaChart)
+              │
+              └── SavingsRateTrendChart (historical rate — Recharts LineChart)
+```
+
+## Charting Architecture
+
+| Chart | Component | Library | Data Source |
+|-------|-----------|---------|-------------|
+| Per-category progress | `BulletChart` | MUI LinearProgress + custom theming | `BudgetProgressSnapshot[].percentage` |
+| Target vs actual | `ComparisonBarChart` | Recharts BarChart | `BudgetProgressSnapshot[]` |
+| Cumulative burn | `BurnUpLineChart` | Recharts AreaChart | Computed daily cumulative from transactions |
+| Savings rate gauge | `SavingsRateGauge` | MUI Radial gauge or custom SVG | Engine `savingsRate` output |
+| Historical trend | `SavingsRateTrendChart` | Recharts LineChart | Monthly snapshots computed from transactions |
+
+## Integration Points
+
+| System | Integration | Direction |
+|--------|-------------|-----------|
+| Finance store | Reads `transactions[]` for progress computation | Budget → Finance (read-only) |
+| Investment tracking | Feeds surplus/savings rate for PAC suggestions | Budget → Invest (read) |
+| Financial projections | Savings rate → prefill projection inputs | Budget → Projections (read) |
+| Config page | Budget module toggle in `IAppModules` | Config → Budget (toggle) |
+| Layout | Nav link in sidebar/drawer behind module toggle | Layout → Budget (nav) |
+
+## Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Budget config storage | Array on user doc (not subcollection) | Simpler, matches existing pattern, budgets are low-volume |
+| Progress persistence | None (computed client-side) | Always consistent with transactions; no sync complexity |
+| Store approach | Standalone Zustand store | Matches investment module separation pattern |
+| Chart library | Recharts v3.8.1 | Already in project, all needed chart types available |
+| Savings rate engine | Pure utility in `src/lib/` | Testable, no side effects, matches projections pattern |
+| Module toggle | New `budgetTracking` key in `IAppModules` | Consistent with car/utilities/investment pattern |
+
+## Related
+
+- [[features/budget-savings-engine]] — Feature description
+- [[features/investment-tracking]] — Investment pipeline (surplus target)
+- [[features/financial-projections]] — Projections (savings rate consumer)
+- [[architecture/system-architecture]] — Overall system architecture
+- [[architecture/investment-tracking-architecture]] — Investment architecture
+- [[architecture/financial-projections-architecture]] — Projections architecture
+- [[plans/budget-savings-engine-implementation]] — Implementation plan
+- Source: [raw/100-budget-savings-engine/issue.md](raw/100-budget-savings-engine/issue.md)

--- a/docs/YATF/features/budget-savings-engine.md
+++ b/docs/YATF/features/budget-savings-engine.md
@@ -3,14 +3,14 @@ title: "Budget & Savings Rate Engine"
 tags: [feature, budget, savings, planned]
 created: 2026-06-28
 updated: 2026-06-28
-status: planned
+status: implemented
 sources: ["raw/100-budget-savings-engine/issue.md"]
 related: ["features/investment-tracking", "features/financial-projections", "features/crud-etf-transactions", "architecture/budget-savings-architecture", "architecture/financial-projections-architecture", "architecture/investment-tracking-architecture"]
 ---
 
 # Feature: Budget & Savings Rate Engine
 
-Status: planned
+Status: implemented
 Priority: high
 
 ## Description

--- a/docs/YATF/features/budget-savings-engine.md
+++ b/docs/YATF/features/budget-savings-engine.md
@@ -1,0 +1,88 @@
+---
+title: "Budget & Savings Rate Engine"
+tags: [feature, budget, savings, planned]
+created: 2026-06-28
+updated: 2026-06-28
+status: planned
+sources: ["raw/100-budget-savings-engine/issue.md"]
+related: ["features/investment-tracking", "features/financial-projections", "features/crud-etf-transactions", "architecture/budget-savings-architecture", "architecture/financial-projections-architecture", "architecture/investment-tracking-architecture"]
+---
+
+# Feature: Budget & Savings Rate Engine
+
+Status: planned
+Priority: high
+
+## Description
+
+Advanced Budgeting and Target Tracking Module that transforms the application from pure investment tracking to full-featured personal finance management with real-time savings rate calculation and optimization. Adds a `/budget` route with budget configuration, progress tracking via Recharts visualizations, and a savings rate engine that bridges operational budgets with the investment pipeline.
+
+## Sub-features
+
+### 1. Core Data Architecture & Schema
+
+Time-aware budget configuration with frequency support, integrated with the existing Firestore user document pattern.
+
+**Requirements:**
+- `BudgetConfig` TypeScript interface with fields: `{ id, category, period: "monthly" | "semiannual" | "annual", targetAmount, color, name? }`
+- `BudgetProgressSnapshot` interface for computed progress data (client-side, not persisted)
+- Budget configs stored in `budgetTargets[]` array on the user Firestore document
+- Support for assigning budgets to expense categories (multi-category, or per-category)
+- Default budget configs seeded from existing category list
+- Integrates with liquidity management (cash accounts) and investment pipelines (surplus routing)
+
+### 2. Advanced UX Visualizations (Recharts)
+
+Three chart types for the `/budget` page, following existing dark-theme Recharts conventions.
+
+**Requirements:**
+
+**Non-Linear Progress Bars (Bullet Charts):**
+- Horizontal gauge per budget category tracking percentage usage
+- Multi-stage coloring: Safe zone (<70% green), Warning zone (71–99% amber), Breach zone (>=100% red)
+- Real-time over-budget impact visualization (show by how much)
+- MUI LinearProgress with custom coloring, or custom Recharts BarChart
+
+**Grouped Comparative Bars:**
+- Dual bar chart per category: Target (ghost bar) vs. Actual (filled bar)
+- Time-period selector to view different months/periods
+- Show temporal volatility — which categories consistently over/under-budget
+
+**Accumulative Burn-Up Line Chart:**
+- Time-based trajectory visualization for macro targets (total budget)
+- Ideal burn rate (linear target ÷ days) vs. Actual spend rate (cumulative)
+- Predicts end-of-period overshoot/undershoot based on current velocity
+
+### 3. "Savings Rate Target" Engine
+
+A pure client-side computation engine that calculates savings rate and provides a real-time feedback loop.
+
+**Requirements:**
+- Formula: `(Total Income − Total Expenses) / Total Income` for the selected period
+- Breakdown visualization: where income is going (expenses by category, savings, investments)
+- Live gauge component showing current savings rate vs. target rate
+- Historical savings rate trend (line chart over past months)
+- Comparison to target rate (configurable in BudgetConfig)
+- Suggested investment allocation based on surplus (bridge to `/invest`)
+
+## Integration Points
+
+| System | Connection |
+|--------|------------|
+| Finance transactions | Budget progress computed from `transactions[]` filtered by category + date |
+| Category system | Budgets assigned to `categories[]` — expense categories only |
+| Investment tracking | Savings rate surplus → suggested PAC amounts in `/invest` |
+| Financial projections | Savings rate data can prefill projection inputs |
+| Firestore | `budgetTargets[]` stored in user document alongside existing arrays |
+| Config page | Budget module toggle in `IAppModules` + budget settings |
+
+## Related
+
+- [[features/investment-tracking]] — Investment pipeline, target for surplus routing
+- [[features/financial-projections]] — Projections simulation fed by savings rate data
+- [[features/crud-etf-transactions]] — Transaction patterns
+- [[architecture/budget-savings-architecture]] — Architecture & data flow
+- [[architecture/financial-projections-architecture]] — Projections data flow
+- [[architecture/investment-tracking-architecture]] — Investment tracking architecture
+- [[plans/budget-savings-engine-implementation]] — Implementation plan
+- Source: [raw/100-budget-savings-engine/issue.md](raw/100-budget-savings-engine/issue.md)

--- a/docs/YATF/features/guida-investimenti.md
+++ b/docs/YATF/features/guida-investimenti.md
@@ -1,11 +1,11 @@
 ---
-title: "Monitoraggio Investimenti e Proiezioni Finanziarie — Guida Utente"
-tags: [feature, investment, projections, guide, italiano]
+title: "Monitoraggio Investimenti, Proiezioni e Budget — Guida Utente"
+tags: [feature, investment, projections, budget, guide, italiano]
 created: 2026-06-27
 updated: 2026-06-28
 status: active
 sources: ["raw/FEATURES-GUIDE.it.md"]
-related: ["features/investment-tracking-guide", "features/investment-tracking", "features/investment-tracking-v3", "features/financial-projections", "features/multi-broker-architecture", "features/crud-etf-transactions", "features/pac-automation", "features/historical-snapshots", "features/tax-inflation-modeling", "features/ticker-validation"]
+related: ["features/investment-tracking-guide", "features/investment-tracking", "features/investment-tracking-v3", "features/financial-projections", "features/budget-savings-engine", "features/multi-broker-architecture", "features/crud-etf-transactions", "features/pac-automation", "features/historical-snapshots", "features/tax-inflation-modeling", "features/ticker-validation"]
 ---
 
 # Guida Utente: Monitoraggio Investimenti e Proiezioni Finanziarie
@@ -158,4 +158,6 @@ Se il broker è configurato in Investimenti, la pagina Proiezioni carica automat
 - [[features/historical-snapshots]]
 - [[features/tax-inflation-modeling]]
 - [[features/ticker-validation]]
+- [[features/budget-savings-engine]]
+- [[architecture/budget-savings-architecture]]
 - Fonte: [raw/FEATURES-GUIDE.it.md](raw/FEATURES-GUIDE.it.md)

--- a/docs/YATF/features/investment-tracking-guide.md
+++ b/docs/YATF/features/investment-tracking-guide.md
@@ -1,11 +1,11 @@
 ---
-title: "Investment Tracking & Financial Projections — User Guide"
-tags: [feature, investment, projections, guide]
+title: "Investment Tracking & Financial Projections & Budget — User Guide"
+tags: [feature, investment, projections, budget, guide]
 created: 2026-06-27
 updated: 2026-06-28
 status: active
 sources: ["raw/FEATURES-GUIDE.md"]
-related: ["features/guida-investimenti", "features/investment-tracking", "features/investment-tracking-v3", "features/financial-projections", "features/multi-broker-architecture", "features/crud-etf-transactions", "features/pac-automation", "features/historical-snapshots", "features/tax-inflation-modeling", "features/ticker-validation", "architecture/investment-tracking-architecture", "architecture/financial-projections-architecture"]
+related: ["features/guida-investimenti", "features/investment-tracking", "features/investment-tracking-v3", "features/financial-projections", "features/budget-savings-engine", "features/multi-broker-architecture", "features/crud-etf-transactions", "features/pac-automation", "features/historical-snapshots", "features/tax-inflation-modeling", "features/ticker-validation", "architecture/investment-tracking-architecture", "architecture/financial-projections-architecture", "architecture/budget-savings-architecture"]
 ---
 
 # User Guide: Investment Tracking & Financial Projections
@@ -145,6 +145,36 @@ If broker settings are configured in Investments, the Projections page auto-fill
 - Tax is flat 26% on capital gains (Italian regime)
 - Inflation adjustment is off by default; toggle it on for real purchasing power
 
+## 3. Budget & Savings Rate (`/budget`)
+
+Track your spending against configurable budget targets and monitor your savings rate in real time.
+
+### Getting Started
+
+1. **Enable the module**: Go to **Settings** (`/config`) → *Active Modules* → toggle **Budget Tracking** on.
+2. **Add budget targets**: Click **Add Budget** to create targets with category, period (monthly/semiannual/annual), target amount, and colour.
+
+### Dashboard
+
+- **Savings Rate Gauge**: Circular gauge showing `(Income − Expenses) / Income`. Green (≥20%), Amber (10–19%), Red (<10%).
+- **Summary Cards**: Total Budgeted, Total Spent, Remaining, Savings Rate %.
+- **Progress by Category**: Bullet bars with Safe (<70%), Warning (71–99%), Breach (≥100%) zones.
+- **Target vs Actual**: Recharts grouped bar chart — target (ghost) vs actual (filled).
+- **Burn-up Trend**: Cumulative spend (actual) vs ideal linear burn rate (dashed).
+- **Budget Targets list**: Edit/delete each configured target.
+
+### Savings Rate Formula
+
+```
+Rate = (Total Income − Total Expenses) / Total Income
+```
+
+Computed live from your existing transactions — no additional setup needed.
+
+### Integration with Investments
+
+Surplus and savings rate are displayed on `/budget`, bridging day-to-day budgeting with the investment pipeline.
+
 ## Data Flow Between Features
 
 ```
@@ -174,4 +204,6 @@ Setting up your broker means you don't have to re-enter numbers on the Projectio
 - [[features/ticker-validation]]
 - [[architecture/investment-tracking-architecture]]
 - [[architecture/financial-projections-architecture]]
+- [[features/budget-savings-engine]]
+- [[architecture/budget-savings-architecture]]
 - Source: [raw/FEATURES-GUIDE.md](raw/FEATURES-GUIDE.md)

--- a/docs/YATF/index.md
+++ b/docs/YATF/index.md
@@ -1,6 +1,6 @@
 # Wiki Index
 
-*Last updated: 2026-06-28* (V4 Budget & Savings Rate Engine ingested)
+*Last updated: 2026-06-28* (V4 Budget & Savings Rate Engine implemented + guides updated)
 *Total pages: 33*
 
 ---
@@ -13,8 +13,8 @@
 | [[features/transaction-layout-improvement]] | Two-column transaction layout with filter + chart on left | [#80](https://github.com/AlexDevsTheWeb/myfinance/issues/80) |
 | [[features/investment-tracking]] | ✅ ETF portfolio tracking, broker integration, PAC strategy, and asset-vs-expense separation | [`raw/81-tax-refund/`](raw/81-tax-refund/) |
 | [[features/financial-projections]] | ✅ Compound interest simulator with parametric sliders and real-time chart | [`#83`](https://github.com/AlexDevsTheWeb/myfinance/issues/83) |
-| [[features/investment-tracking-guide]] | 📘 User guide — Investment Tracking & Financial Projections (EN) | [`raw/FEATURES-GUIDE.md`](raw/FEATURES-GUIDE.md) |
-| [[features/guida-investimenti]] | 📘 Guida utente — Monitoraggio Investimenti e Proiezioni (IT) | [`raw/FEATURES-GUIDE.it.md`](raw/FEATURES-GUIDE.it.md) |
+| [[features/investment-tracking-guide]] | 📘 User guide — Investment, Projections & Budget (EN) | [`raw/FEATURES-GUIDE.md`](raw/FEATURES-GUIDE.md) |
+| [[features/guida-investimenti]] | 📘 Guida utente — Investimenti, Proiezioni e Budget (IT) | [`raw/FEATURES-GUIDE.it.md`](raw/FEATURES-GUIDE.it.md) |
 | [[features/pac-automation]] | ✅ Automated recurring PAC transactions with confirmation UI | [`#89`](https://github.com/AlexDevsTheWeb/myfinance/issues/89) |
 | [[features/crud-etf-transactions]] | ✅ Edit/delete ETF transactions with safe cascade recalculation | [`#90`](https://github.com/AlexDevsTheWeb/myfinance/issues/90) |
 | [[features/multi-broker-architecture]] | ✅ Multi-broker & multi-asset schema refactor with BrokerSelect | [`#91`](https://github.com/AlexDevsTheWeb/myfinance/issues/91) |
@@ -22,7 +22,7 @@
 | [[features/tax-inflation-modeling]] | ✅ Inflation-adjusted projections with real vs nominal toggle | [`#93`](https://github.com/AlexDevsTheWeb/myfinance/issues/93) |
 | [[features/ticker-validation]] | ✅ Yahoo Finance ticker validation at broker config save | [`#94`](https://github.com/AlexDevsTheWeb/myfinance/issues/94) |
 | [[features/investment-tracking-v3]] | ✅ V3: Dividend ledger, capital gains tax, cash adjustments, performance prefill | [`#98`](https://github.com/AlexDevsTheWeb/myfinance/issues/98) |
-| [[features/budget-savings-engine]] | 🎯 V4: Budget targets, progress tracking, savings rate engine, investment bridge | [`#100`](https://github.com/AlexDevsTheWeb/myfinance/issues/100) |
+| [[features/budget-savings-engine]] | ✅ V4: Budget targets, progress tracking, savings rate engine, investment bridge | [`#100`](https://github.com/AlexDevsTheWeb/myfinance/issues/100) |
 
 ## Plans
 
@@ -35,7 +35,7 @@
 | [[plans/financial-projections-implementation]] | ✅ 3-plan implementation for simulation engine, UI shell, routing + i18n | [`raw/83-financial-projections/issue.md`](raw/83-financial-projections/issue.md) |
 | [[plans/investment-tracking-v2-enhancements]] | ✅ Phase 12 complete — 6 GSD plans implemented (multi-broker, CRUD, PAC, snapshots, inflation, ticker) | [`.planning/phases/12-investment-tracking-v2/`](.planning/phases/12-investment-tracking-v2/) |
 | [[plans/investment-tracking-v3-implementation]] | ✅ V3 implementation: dividend, tax, cash adjustments, performance prefill | [`#98`](https://github.com/AlexDevsTheWeb/myfinance/issues/98) |
-| [[plans/budget-savings-engine-implementation]] | 🎯 V4 Budget & Savings Rate implementation: 6 waves, 11 new files, 10 modified | [`#100`](https://github.com/AlexDevsTheWeb/myfinance/issues/100) |
+| [[plans/budget-savings-engine-implementation]] | ✅ V4 Budget & Savings Rate implementation: 6 waves, 11 new files, 10 modified | [`#100`](https://github.com/AlexDevsTheWeb/myfinance/issues/100) |
 
 ## Architecture
 
@@ -51,7 +51,7 @@
 | [[architecture/concerns-and-tech-debt]] | Tech debt, known bugs, security, performance issues | [`raw/codebase/CONCERNS.md`](raw/codebase/CONCERNS.md) |
 | [[architecture/investment-tracking-architecture]] | ✅ Investment data flow, V1+V2 Firestore schema, store architecture, component tree, migration layer | [`.planning/phases/10-investment-tracking/10-RESEARCH.md`](.planning/phases/10-investment-tracking/10-RESEARCH.md) |
 | [[architecture/financial-projections-architecture]] | ✅ Simulation data flow, component tree, design decisions, integration points | [`raw/83-financial-projections/issue.md`](raw/83-financial-projections/issue.md) |
-| [[architecture/budget-savings-architecture]] | 🎯 Budget data flow, Firestore schema, store architecture, component tree, charting | [`raw/100-budget-savings-engine/issue.md`](raw/100-budget-savings-engine/issue.md) |
+| [[architecture/budget-savings-architecture]] | ✅ Budget data flow, Firestore schema, store architecture, component tree, charting | [`raw/100-budget-savings-engine/issue.md`](raw/100-budget-savings-engine/issue.md) |
 
 ## Conventions
 

--- a/docs/YATF/index.md
+++ b/docs/YATF/index.md
@@ -1,7 +1,7 @@
 # Wiki Index
 
-*Last updated: 2026-06-28* (V3 complete — all 4 sub-features implemented)
-*Total pages: 30*
+*Last updated: 2026-06-28* (V4 Budget & Savings Rate Engine ingested)
+*Total pages: 33*
 
 ---
 
@@ -22,6 +22,7 @@
 | [[features/tax-inflation-modeling]] | ✅ Inflation-adjusted projections with real vs nominal toggle | [`#93`](https://github.com/AlexDevsTheWeb/myfinance/issues/93) |
 | [[features/ticker-validation]] | ✅ Yahoo Finance ticker validation at broker config save | [`#94`](https://github.com/AlexDevsTheWeb/myfinance/issues/94) |
 | [[features/investment-tracking-v3]] | ✅ V3: Dividend ledger, capital gains tax, cash adjustments, performance prefill | [`#98`](https://github.com/AlexDevsTheWeb/myfinance/issues/98) |
+| [[features/budget-savings-engine]] | 🎯 V4: Budget targets, progress tracking, savings rate engine, investment bridge | [`#100`](https://github.com/AlexDevsTheWeb/myfinance/issues/100) |
 
 ## Plans
 
@@ -34,6 +35,7 @@
 | [[plans/financial-projections-implementation]] | ✅ 3-plan implementation for simulation engine, UI shell, routing + i18n | [`raw/83-financial-projections/issue.md`](raw/83-financial-projections/issue.md) |
 | [[plans/investment-tracking-v2-enhancements]] | ✅ Phase 12 complete — 6 GSD plans implemented (multi-broker, CRUD, PAC, snapshots, inflation, ticker) | [`.planning/phases/12-investment-tracking-v2/`](.planning/phases/12-investment-tracking-v2/) |
 | [[plans/investment-tracking-v3-implementation]] | ✅ V3 implementation: dividend, tax, cash adjustments, performance prefill | [`#98`](https://github.com/AlexDevsTheWeb/myfinance/issues/98) |
+| [[plans/budget-savings-engine-implementation]] | 🎯 V4 Budget & Savings Rate implementation: 6 waves, 11 new files, 10 modified | [`#100`](https://github.com/AlexDevsTheWeb/myfinance/issues/100) |
 
 ## Architecture
 
@@ -49,6 +51,7 @@
 | [[architecture/concerns-and-tech-debt]] | Tech debt, known bugs, security, performance issues | [`raw/codebase/CONCERNS.md`](raw/codebase/CONCERNS.md) |
 | [[architecture/investment-tracking-architecture]] | ✅ Investment data flow, V1+V2 Firestore schema, store architecture, component tree, migration layer | [`.planning/phases/10-investment-tracking/10-RESEARCH.md`](.planning/phases/10-investment-tracking/10-RESEARCH.md) |
 | [[architecture/financial-projections-architecture]] | ✅ Simulation data flow, component tree, design decisions, integration points | [`raw/83-financial-projections/issue.md`](raw/83-financial-projections/issue.md) |
+| [[architecture/budget-savings-architecture]] | 🎯 Budget data flow, Firestore schema, store architecture, component tree, charting | [`raw/100-budget-savings-engine/issue.md`](raw/100-budget-savings-engine/issue.md) |
 
 ## Conventions
 

--- a/docs/YATF/log.md
+++ b/docs/YATF/log.md
@@ -179,6 +179,15 @@
 - Updated [[plans/investment-tracking-v3-implementation]] status → **completed**
 - Updated [[features/investment-tracking-v3]] status → **implemented**
 
+## [2026-06-28] ingest | Feature | Budget & Savings Rate Engine V4 — Issue #100
+- Created [[raw/100-budget-savings-engine/issue.md]] from GitHub [Issue #100](https://github.com/AlexDevsTheWeb/myfinance/issues/100)
+- Created [[features/budget-savings-engine]] — 3 sub-features (budget config, Recharts visualizations, savings rate engine)
+- Created [[architecture/budget-savings-architecture]] — data flow, Firestore schema, store architecture, component tree, charting, integration points
+- Created [[plans/budget-savings-engine-implementation]] — 6 waves, 11 new files, 10 modified files, with full architecture analysis
+- Updated [[architecture/investment-tracking-architecture]] — added budget integration section (surplus → investment bridge)
+- Updated [[architecture/financial-projections-architecture]] — added savings rate bridge section
+- Updated index.md (33 pages) and log.md
+
 ## [2026-06-28] docs | Guide | V3 features added to FEATURES-GUIDE (EN/IT)
 - Updated `raw/FEATURES-GUIDE.md` — added Cash Adjustments, Dividends, Tax Pocket, and Use Real Performance sections
 - Updated `raw/FEATURES-GUIDE.it.md` — Italian version with same V3 additions

--- a/docs/YATF/log.md
+++ b/docs/YATF/log.md
@@ -188,6 +188,18 @@
 - Updated [[architecture/financial-projections-architecture]] — added savings rate bridge section
 - Updated index.md (33 pages) and log.md
 
+## [2026-06-28] implement | Feature | Budget & Savings Rate Engine V4 — Full /budget module
+- Implemented 6 waves across 29 files (1882 insertions)
+- Created [[features/budget-savings-engine]] status → **implemented**
+- Created [[architecture/budget-savings-architecture]] status → **active**
+- Created [[plans/budget-savings-engine-implementation]] status → **completed**
+- Updated [[features/investment-tracking-guide]] → added Budget section, renamed to include Budget
+- Updated [[features/guida-investimenti]] → added Budget section, renamed to include Budget
+- Updated [[architecture/investment-tracking-architecture]] — added budget integration section
+- Updated [[architecture/financial-projections-architecture]] — added savings rate bridge
+- Updated FEATURES-GUIDE.md and FEATURES-GUIDE.it.md with Budget section
+- Updated index.md and log.md
+
 ## [2026-06-28] docs | Guide | V3 features added to FEATURES-GUIDE (EN/IT)
 - Updated `raw/FEATURES-GUIDE.md` — added Cash Adjustments, Dividends, Tax Pocket, and Use Real Performance sections
 - Updated `raw/FEATURES-GUIDE.it.md` — Italian version with same V3 additions

--- a/docs/YATF/plans/budget-savings-engine-implementation.md
+++ b/docs/YATF/plans/budget-savings-engine-implementation.md
@@ -1,0 +1,445 @@
+---
+title: "Budget & Savings Rate Engine — Implementation Plan"
+tags: [plan, budget, savings, draft]
+created: 2026-06-28
+updated: 2026-06-28
+status: draft
+sources: ["raw/100-budget-savings-engine/issue.md"]
+related: ["features/budget-savings-engine", "features/budget-savings-architecture", "features/investment-tracking", "features/financial-projections", "architecture/budget-savings-architecture", "architecture/investment-tracking-architecture", "architecture/financial-projections-architecture"]
+---
+
+# Plan: Budget & Savings Rate Engine — Implementation
+
+Status: draft
+
+## Goal
+
+Implement a full Budget & Savings Rate module (`/budget`) with budget target configuration, real-time progress tracking via Recharts visualizations, and a savings rate engine that bridges operational budgets with the investment pipeline.
+
+## Architecture Analysis
+
+### Pattern Fit
+
+The budget module follows the exact same architectural patterns as the existing investment tracking module:
+
+| Aspect | Investment (reference) | Budget (new) |
+|--------|----------------------|--------------|
+| Store | `useInvestmentStore.ts` (standalone Zustand) | `useBudgetStore.ts` (standalone Zustand) |
+| Types | `investment.types.ts` | `budget.types.ts` |
+| Firestore | Array fields on user doc | `budgetTargets[]` on user doc |
+| Sync | `useInvestmentSync.ts` | `useBudgetSync.ts` |
+| Defaults | In `getDefaultUserConfig()` | Seed in `getDefaultUserConfig()` |
+| Module toggle | `investmentTracking` in `IAppModules` | `budgetTracking` in `IAppModules` |
+
+### Key Difference from Investment Module
+
+Budget **progress is not persisted** — it's computed live from `transactions[]` by a pure utility function. This means:
+- No Firestore writes for progress data
+- No subcollection to manage
+- Progress is always consistent with current transactions
+- Computation must be efficient (filter + sum over date range + per category)
+
+### Cross-Module Dependencies
+
+The budget module is read-only consumer of the finance store's `transactions[]`. It does **not** modify finance data. The savings rate engine bridges to investment by computing surplus that could feed PAC suggestions, but the bridge is advisory (display-only in V4, actionable in future versions).
+
+## Implementation Order
+
+| Order | Wave | Feature | Dependencies | Effort |
+|-------|------|---------|-------------|--------|
+| 1 | Wave 1 | Types, Store, Sync, Defaults, Firestore rules | None | Medium |
+| 2 | Wave 2 | Budget Engine (pure computation utility) | Wave 1 | Medium |
+| 3 | Wave 3 | UI — BudgetPage shell + SavingsRateGauge + SummaryCards | Wave 2 | Medium |
+| 4 | Wave 4 | UI — BulletChart + ComparisonBarChart + BurnUpLineChart | Wave 2 | Large |
+| 5 | Wave 5 | Routing, Nav, Module Toggle, i18n | Wave 1 | Small |
+| 6 | Wave 6 | Savings rate → Investment bridge (surplus display) | Wave 3, invest store | Small |
+
+**Rationale:** Types/store first (foundation). Engine second (core logic, testable independently). UI waves build on the engine output. Navigation/i18n waves are lightweight wiring. The investment bridge is last because it's additive on top of completed module.
+
+---
+
+## Wave 1 — Types, Store, Sync, Defaults, Firestore Rules
+
+### Files to create
+- `src/store/types/budget.types.ts` — `BudgetTarget` interface, CRUD action types
+- `src/store/useBudgetStore.ts` — Zustand store with CRUD actions
+- `src/store/useBudgetSync.ts` — Firestore sync hook
+
+### Files to modify
+- `src/store/types/index.ts` — export budget types
+- `src/store/types/finance.types.ts` — add `budgetTracking: boolean` to `IAppModules`
+- `src/lib/converters.ts` — add `budgetTargets` to `UserDoc` interface and firestore converters (`fromFirestore`, `toFirestore`)
+- `src/store/sync/index.ts` — add `budgetTargets: []` to `getDefaultUserConfig()`, import + call `useBudgetSync` in initialization
+- `firestore.rules` — add read/write rules for `budgetTargets` field
+
+### BudgetTarget type
+```typescript
+export interface BudgetTarget {
+  id: string;
+  category: string;
+  period: 'monthly' | 'semiannual' | 'annual';
+  targetAmount: number;
+  color: string;
+  name?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+### Store actions
+```typescript
+interface BudgetStore {
+  budgetTargets: BudgetTarget[];
+  isSaving: boolean;
+  saveError: string | null;
+
+  addBudgetTarget: (target: Omit<BudgetTarget, 'id' | 'createdAt' | 'updatedAt'>) => Promise<void>;
+  updateBudgetTarget: (id: string, updates: Partial<BudgetTarget>) => Promise<void>;
+  deleteBudgetTarget: (id: string) => Promise<void>;
+  setBudgetTargets: (targets: BudgetTarget[]) => void;
+}
+```
+
+### Firestore rules addition
+```javascript
+match /users/{userId} {
+  // ... existing rules
+  
+  // Budget targets field-level read/write
+  allow read: if request.auth != null && request.auth.uid == userId;
+  // Allow write on the budgetTargets field
+  // (already covered by document-level write rule if using field writes)
+}
+```
+
+---
+
+## Wave 2 — Budget Engine (Pure Computation Utility)
+
+### File to create
+- `src/lib/budgetEngine.ts` — pure computation functions
+
+### Functions
+```typescript
+export interface BudgetProgressSnapshot {
+  category: string;
+  targetAmount: number;
+  actualSpent: number;
+  percentage: number;
+  remaining: number;
+  status: 'safe' | 'warning' | 'breach';
+  periodStart: string;
+  periodEnd: string;
+}
+
+export interface PeriodSummary {
+  totalIncome: number;
+  totalExpenses: number;
+  savingsRate: number;
+  totalBudgeted: number;
+  totalSpent: number;
+  surplus: number;
+  dailyBurnRate: number;
+  daysRemaining: number;
+  projectedOvershoot: number;
+}
+
+export function computeBudgetProgress(
+  transactions: ITransaction[],
+  budgetTargets: BudgetTarget[],
+  dateRange: { start: string; end: string }
+): {
+  snapshots: BudgetProgressSnapshot[];
+  summary: PeriodSummary;
+} { /* ... */ }
+
+export function computeSavingsRate(
+  transactions: ITransaction[],
+  dateRange: { start: string; end: string }
+): number { /* ... */ }
+
+export function computeHistoricalSavingsRate(
+  transactions: ITransaction[],
+  months: number
+): { month: string; rate: number }[] { /* ... */ }
+
+export function computeBurnUpData(
+  transactions: ITransaction[],
+  budgetTargets: BudgetTarget[],
+  dateRange: { start: string; end: string }
+): { date: string; actual: number; ideal: number }[] { /* ... */ }
+```
+
+### Computation logic
+
+**Budget progress per category:**
+```
+filter transactions by category + date range + type === 'expense'
+sum amounts (absolute value)
+percentage = actualSpent / targetAmount * 100
+status = percentage < 70 ? 'safe' : percentage < 100 ? 'warning' : 'breach'
+remaining = targetAmount - actualSpent
+```
+
+**Savings rate:**
+```
+totalIncome = sum of income transactions in date range
+totalExpenses = sum of expense transactions (absolute) in date range
+rate = (totalIncome - totalExpenses) / totalIncome
+```
+
+**Burn-up data:**
+```
+daysInPeriod = endDate - startDate
+per-day ideal = totalBudget / daysInPeriod
+for each transaction date (sorted), compute cumulative actual
+for each day, ideal = (dayIndex / daysInPeriod) * totalBudget
+```
+
+---
+
+## Wave 3 — BudgetPage Shell + SavingsRateGauge + SummaryCards
+
+### Files to create
+- `src/pages/BudgetPage.tsx` — main page component
+- `src/components/budget/SavingsRateGauge.tsx` — savings rate gauge (MUI CircularProgress or custom)
+- `src/components/budget/BudgetSummaryCards.tsx` — 4 summary metric cards
+
+### BudgetPage structure
+```typescript
+function BudgetPage() {
+  const { budgetTargets } = useBudgetStore();
+  const { transactions } = useFinanceStore();
+  const [dateRange, setDateRange] = useState({ start, end });
+
+  const { snapshots, summary } = useMemo(
+    () => computeBudgetProgress(transactions, budgetTargets, dateRange),
+    [transactions, budgetTargets, dateRange]
+  );
+
+  return (
+    <>
+      <PeriodSelector value={dateRange} onChange={setDateRange} />
+      <SavingsRateGauge rate={summary.savingsRate} />
+      <BudgetSummaryCards summary={summary} />
+      <BudgetCategoryList snapshots={snapshots} />
+      <ComparisonBarChart snapshots={snapshots} />
+      <BurnUpLineChart transactions={transactions} targets={budgetTargets} dateRange={dateRange} />
+    </>
+  );
+}
+```
+
+### SavingsRateGauge
+- Uses MUI `CircularProgress` with `variant="determinate"`
+- Color: green >20%, amber 10–20%, red <10%
+- Shows current rate % + target rate % with diff indicator
+- Placement: top of page, hero-style
+
+### BudgetSummaryCards
+- MUI `Grid` of 4 `Paper` cards:
+  - Total Budgeted (sum of all target amounts)
+  - Total Spent (sum of actual expenses in budget categories)
+  - Remaining (totalBudgeted − totalSpent)
+  - Savings Rate % (highlighted, largest card)
+
+---
+
+## Wave 4 — Recharts Visualizations
+
+### Files to create
+- `src/components/budget/BulletChart.tsx` — per-category progress bars
+- `src/components/budget/ComparisonBarChart.tsx` — target vs actual bars
+- `src/components/budget/BurnUpLineChart.tsx` — cumulative burn-up trajectory
+
+### BulletChart (per-category)
+- Uses MUI `LinearProgress` with custom `sx` theming for color zones
+- Shows: category name, progress bar (color-coded), spent/target, percentage text
+- Threshold lines: safe/warning/breach zone indicators
+- Multiple bars rendered in a list layout
+
+### ComparisonBarChart
+- Recharts `BarChart` with `ResponsiveContainer`
+- Two `Bar` series per category: Target (ghost/faded), Actual (filled)
+- X-axis: category names
+- Y-axis: EUR amount
+- Legend: Target vs Actual
+- Color: actual bar inherits from BudgetTarget.color
+
+### BurnUpLineChart
+- Recharts `AreaChart` with `ResponsiveContainer`
+- Two `Area` series: Ideal (dashed line), Actual (filled gradient)
+- X-axis: dates (daily or weekly ticks)
+- Y-axis: cumulative EUR
+- Tooltip showing actual, ideal, variance
+
+### Chart theming
+Follow existing dark-theme conventions from other chart components:
+```typescript
+const chartTheme = {
+  background: '#161b2e',
+  grid: 'rgba(255,255,255,0.05)',
+  axis: 'rgba(255,255,255,0.5)',
+  tooltip: { background: '#1e293b', border: 'rgba(255,255,255,0.1)' },
+};
+```
+
+---
+
+## Wave 5 — Routing, Nav, Module Toggle, i18n
+
+### Files to modify
+- `src/App.tsx` — add `/budget` route with `ProtectedRoute` + lazy loading
+- `src/components/layout/Layout.tsx` — add nav link for budget (conditionally shown)
+- `src/pages/ConfigPage.tsx` — add budget toggle switch
+- `src/store/types/finance.types.ts` — add `budgetTracking` to IAppModules
+- `src/i18n/en.json` — budget namespace translations
+- `src/i18n/it.json` — budget namespace translations
+
+### Route definition
+```typescript
+const BudgetPage = React.lazy(() => import('../pages/BudgetPage'));
+
+<Route path="/budget" element={
+  <ProtectedRoute>
+    <BudgetPage />
+  </ProtectedRoute>
+} />
+```
+
+### Nav link
+```typescript
+{enabledModules?.budgetTracking && (
+  <ListItemButton component={Link} to="/budget">
+    <ListItemIcon><AccountBalanceWalletIcon /></ListItemIcon>
+    <ListItemText primary={t('nav.budget')} />
+  </ListItemButton>
+)}
+```
+
+### Module toggle
+```typescript
+// In IAppModules
+interface IAppModules {
+  // ... existing
+  budgetTracking: boolean;
+}
+```
+
+### i18n keys
+```
+budget:
+  title: "Budget"
+  savingsRate: "Savings Rate"
+  totalBudgeted: "Total Budgeted"
+  totalSpent: "Total Spent"
+  remaining: "Remaining"
+  targetVsActual: "Target vs Actual"
+  burnUp: "Burn-up Trend"
+  period: "Period"
+  addBudget: "Add Budget Target"
+  editBudget: "Edit Budget Target"
+  deleteBudget: "Delete Budget Target"
+  category: "Category"
+  targetAmount: "Target Amount"
+  periodMonthly: "Monthly"
+  periodSemiannual: "Semiannual"
+  periodAnnual: "Annual"
+  safe: "On Track"
+  warning: "Approaching Limit"
+  breach: "Over Budget"
+nav:
+  budget: "Budget"
+config:
+  budgetTracking: "Budget Tracking"
+```
+
+---
+
+## Wave 6 — Savings Rate → Investment Bridge
+
+### Files to create/modify
+- `src/components/budget/InvestmentBridgeCard.tsx` — surplus suggestion card
+- `src/components/investment/` or `BudgetPage.tsx` — integration point
+
+### InvestmentBridgeCard
+- Displays on BudgetPage when surplus > 0
+- Shows: "€X surplus this month — consider increasing your PAC"
+- Quick-action button: "Apply to Investment" (prefills PAC amount in invest store)
+- Links to `/invest` page
+
+### Integration logic
+```
+surplus = totalIncome − totalExpenses (from PeriodSummary)
+suggestedPacIncrease = surplus * 0.5  // 50% of surplus
+currentPac = brokerConfig.monthlyPacAmount
+newSuggestedPac = currentPac + suggestedPacIncrease
+```
+
+---
+
+## Files: Complete Change List
+
+### Create
+| File | Wave |
+|------|------|
+| `src/store/types/budget.types.ts` | 1 |
+| `src/store/useBudgetStore.ts` | 1 |
+| `src/store/useBudgetSync.ts` | 1 |
+| `src/lib/budgetEngine.ts` | 2 |
+| `src/pages/BudgetPage.tsx` | 3 |
+| `src/components/budget/SavingsRateGauge.tsx` | 3 |
+| `src/components/budget/BudgetSummaryCards.tsx` | 3 |
+| `src/components/budget/BulletChart.tsx` | 4 |
+| `src/components/budget/ComparisonBarChart.tsx` | 4 |
+| `src/components/budget/BurnUpLineChart.tsx` | 4 |
+| `src/components/budget/InvestmentBridgeCard.tsx` | 6 |
+
+### Modify
+| File | Change | Wave |
+|------|--------|------|
+| `src/store/types/finance.types.ts` | Add `budgetTracking` to IAppModules | 1 |
+| `src/store/types/index.ts` | Export budget types | 1 |
+| `src/lib/converters.ts` | Add `budgetTargets` to UserDoc | 1 |
+| `src/store/sync/index.ts` | Default budget config + sync hook | 1 |
+| `firestore.rules` | Budget field access rules | 1 |
+| `src/App.tsx` | Add `/budget` route | 5 |
+| `src/components/layout/Layout.tsx` | Add budget nav link | 5 |
+| `src/pages/ConfigPage.tsx` | Budget module toggle | 5 |
+| `src/i18n/en.json` | Budget translations (EN) | 5 |
+| `src/i18n/it.json` | Budget translations (IT) | 5 |
+
+### Total: 11 new files, 10 modified files
+
+## Verification
+
+1. **TypeScript:** `npm run build` passes without type errors
+2. **Lint:** `npm run lint` passes
+3. **Firebase emulator:** Budget CRUD operations persist to Firestore correctly
+4. **Edge cases:**
+   - Budget with no transactions → 0% spent, all green
+   - Budget heavily exceeded → 200%+ shows breach
+   - Empty budget targets → page shows empty state with "Add Budget" CTA
+   - Month boundary → correct date filtering
+   - No income in period → savings rate = -infinity (handle division by zero)
+5. **Cross-module:**
+   - Adding a transaction in `/transactions` → budget progress updates on `/budget`
+   - Toggling budget module off → nav link disappears, route redirects
+   - Savings rate matches manual calculation
+
+## Dependencies
+
+- [[features/investment-tracking]] — Investment pipeline (bridge target)
+- [[features/financial-projections]] — Projections (future bridge)
+- [[features/crud-etf-transactions]] — Transaction patterns reference
+- [[architecture/budget-savings-architecture]] — Architecture & data flow
+- [[architecture/investment-tracking-architecture]] — Existing store pattern reference
+- [[architecture/financial-projections-architecture]] — Pure computation engine pattern
+- [[architecture/system-architecture]] — Overall architecture
+- [[architecture/tech-stack]] — Tech stack reference (Recharts, MUI)
+
+## Related
+
+- [[features/budget-savings-engine]] — Feature description
+- [[features/budget-savings-architecture]] — Architecture
+- Source: [raw/100-budget-savings-engine/issue.md](raw/100-budget-savings-engine/issue.md)

--- a/docs/YATF/plans/budget-savings-engine-implementation.md
+++ b/docs/YATF/plans/budget-savings-engine-implementation.md
@@ -3,14 +3,14 @@ title: "Budget & Savings Rate Engine — Implementation Plan"
 tags: [plan, budget, savings, draft]
 created: 2026-06-28
 updated: 2026-06-28
-status: draft
+status: completed
 sources: ["raw/100-budget-savings-engine/issue.md"]
 related: ["features/budget-savings-engine", "features/budget-savings-architecture", "features/investment-tracking", "features/financial-projections", "architecture/budget-savings-architecture", "architecture/investment-tracking-architecture", "architecture/financial-projections-architecture"]
 ---
 
 # Plan: Budget & Savings Rate Engine — Implementation
 
-Status: draft
+Status: completed
 
 ## Goal
 

--- a/docs/YATF/raw/100-budget-savings-engine/issue.md
+++ b/docs/YATF/raw/100-budget-savings-engine/issue.md
@@ -1,0 +1,59 @@
+# [FEATURE] Budget & Savings Rate Engine: Advanced Budgeting Module V4
+
+> Source: GitHub Issue [#100](https://github.com/AlexDevsTheWeb/myfinance/issues/100)
+> State: OPEN
+> Labels: feature
+> Created: 2026-06-28
+
+## Context
+
+Advanced Budgeting and Target Tracking Module V4 — transforms the application from pure investment tracking to full-featured personal finance management with real-time savings rate calculation and optimization.
+
+**Development Area of Impact:** Financial Planning & Capital Flow Management
+
+## Features
+
+### 1. Core Data Architecture & Schema
+
+- **Relational & Time-Flexible Data Structure**
+- Implement time-aware budget configuration with frequency support
+- Create `BudgetConfig` and `BudgetProgressSnapshot` TypeScript interfaces
+- Support granular tracking: monthly, semiannual, and annual targets
+- Integrate with liquidity management and investment pipelines
+
+### 2. Advanced UX Visualizations (Recharts)
+
+- **Non-Linear Progress Bars (Bullet Charts)**
+  - Horizontal dynamic gauges tracking budget percentage usage
+  - Multi-stage coloring: Safe zone (<70%), Warning zone (71-99%), Breach zone (>=100%)
+  - Real-time over-budget impact visualization
+
+- **Grouped Comparative Bars**
+  - Dual bar charts: Target vs. Actual spending
+  - Show temporal volatility and boundary compliance
+
+- **Accumulative Burn-Up Line Chart**
+  - Time-based trajectory visualization for macro targets
+  - Ideal vs. actual spend rate comparison
+
+### 3. "Savings Rate Target" Engine
+
+- **Financial Engineering Logic**
+  - Calculate: (Total Income - General Expenses) / Total Income
+  - Track actual investment efficiency vs. targets
+
+- **Real-Time Feedback Loop**
+  - Live gauge indicating savings rate optimization
+  - Automated suggestions for investment allocation based on surplus
+  - Direct bridge between operational budgets and investment pipelines
+
+**Priority:** HIGH
+**Dependencies:** None - Standalone module with integration points to /invest and /cash
+
+## Related
+
+- [[features/investment-tracking]] — V1-V3 investment tracking foundation
+- [[features/financial-projections]] — Projections simulation (bridge for savings rate impact)
+- [[features/crud-etf-transactions]] — Transaction patterns (reusable for budget txns)
+- [[architecture/financial-projections-architecture]] — Projections data flow
+- [[architecture/investment-tracking-architecture]] — Investment tracking architecture

--- a/docs/YATF/raw/FEATURES-GUIDE.it.md
+++ b/docs/YATF/raw/FEATURES-GUIDE.it.md
@@ -219,3 +219,82 @@ Se hai una cronologia del portafoglio, puoi attivare **"Usa Performance Reali"**
 Gli snapshot del portafoglio dalle tue transazioni vengono automaticamente salvati per la visualizzazione dei grafici su più dispositivi.
 
 I movimenti di cassa e le registrazioni dividendi ti permettono di tracciare flussi di cassa esterni e redditi da investimenti separatamente dalle attività di acquisto/vendita ETF.
+
+---
+
+## 3. Budget e Tasso di Risparmio (`/budget`)
+
+Monitora le tue spese rispetto a obiettivi di budget configurabili e tieni traccia del tuo tasso di risparmio in tempo reale. La pagina `/budget` mostra quanto stai spendendo per categoria, come si confronta con i tuoi obiettivi e qual è il tuo tasso di risparmio complessivo.
+
+### Per Iniziare
+
+1. **Attiva il modulo**: Vai su **Impostazioni** (`/config`) → *Moduli Attivi* → attiva **Gestione Budget**.
+2. **Aggiungi obiettivi di budget**: Nella pagina Budget, clicca **Aggiungi Budget** per creare il tuo primo obiettivo. Per ogni obiettivo compila:
+   - **Nome (opzionale)** — un'etichetta leggibile (predefinito: il nome della categoria)
+   - **Categoria** — la categoria di spesa a cui si applica questo budget (es. *Casa*, *Trasporti*, *Spese quotidiane*)
+   - **Periodo** — ogni quanto si resetta l'obiettivo: **Mensile**, **Semestrale** o **Annuale**
+   - **Importo Obiettivo (€)** — quanto prevedi di spendere in questa categoria per periodo
+   - **Colore** — scegli un colore per i grafici
+
+Puoi aggiungere, modificare o eliminare obiettivi in qualsiasi momento.
+
+### Selettore Periodo
+
+Usa il menu a tendina **Periodo** nella parte superiore della pagina per passare tra vista Mensile, Semestrale e Annuale. Tutte le metriche e i grafici si aggiornano in tempo reale per riflettere il periodo selezionato.
+
+### Leggere la Dashboard
+
+**Indicatore Tasso di Risparmio** (in cima alla pagina):
+Un indicatore circolare che mostra il tuo tasso di risparmio corrente: `(Entrate Totali − Uscite Totali) / Entrate Totali` per il periodo selezionato. Colori:
+- **Verde** (≥20%) — tasso di risparmio sano
+- **Ambra** (10–19%) — moderato
+- **Rosso** (<10%) — necessita attenzione
+
+**Carte di Riepilogo** (sotto l'indicatore):
+Quattro carte metriche per una visione d'insieme:
+| Carta | Cosa Mostra |
+|-------|-------------|
+| **Budget Totale** | Somma di tutti gli importi obiettivo per il periodo |
+| **Totale Speso** | Somma delle spese effettive nelle categorie con budget |
+| **Rimanente** | Budget Totale meno Totale Speso |
+| **Tasso di Risparmio** | Percentuale del tasso di risparmio complessivo (evidenziata) |
+
+**Progresso per Categoria** (grafico a barre):
+Per ogni obiettivo di budget impostato, una barra di progresso orizzontale mostra:
+- **Verde** (<70%) — in linea, zona sicura
+- **Ambra** (71–99%) — in avvicinamento al limite, zona di avviso
+- **Rosso** (≥100%) — fuori budget, zona di superamento
+
+Ogni barra mostra il nome della categoria, l'importo effettivo rispetto all'obiettivo e la percentuale utilizzata.
+
+**Obiettivo vs Reale** (grafico a barre raggruppate):
+Un grafico a barre Recharts che confronta l'importo obiettivo di ogni categoria (barra trasparente) con la spesa effettiva (barra piena). Aiuta a individuare quali categorie sono costantemente sopra o sotto budget.
+
+**Andamento Progressivo** (grafico ad area):
+Un grafico ad area che mostra la spesa cumulativa nel tempo (linea effettiva) rispetto al tasso di consumo lineare ideale (linea tratteggiata). La linea ideale presuppone che tu spenda il budget totale in modo uniforme durante il periodo. Se la linea effettiva è sopra quella ideale, stai spendendo più velocemente del previsto.
+
+**Obiettivi di Budget** (elenco):
+In fondo alla pagina, un elenco di tutti i tuoi obiettivi configurati con controlli di modifica/eliminazione. Ogni elemento mostra la categoria, il periodo, l'importo e l'indicatore di colore.
+
+### Come Viene Calcolato il Tasso di Risparmio
+
+```
+Tasso di Risparmio = (Entrate Totali − Uscite Totali) / Entrate Totali
+
+Dove:
+  Entrate Totali = Somma di tutte le transazioni di entrata nel periodo
+  Uscite Totali  = Somma di tutte le transazioni di uscita nel periodo
+```
+
+Il tasso viene visualizzato come percentuale. Un tasso del 25% significa che risparmi €1 per ogni €4 guadagnati.
+
+### Integrazione con gli Investimenti
+
+Il surplus (Budget Totale − Totale Speso) e il tasso di risparmio vengono visualizzati nella pagina Budget. Questi valori ti danno un'indicazione di quanto è disponibile per gli investimenti — un ponte diretto tra la gestione del budget quotidiano e il tuo pipeline di investimenti in `/invest`.
+
+### Note
+
+- Il progresso del budget viene calcolato in tempo reale dalle tue transazioni esistenti — aggiungere una transazione in `/transactions` aggiorna immediatamente tutte le metriche del budget
+- Gli obiettivi di budget sono salvati nel tuo account Firestore e sincronizzati tra i dispositivi
+- Il tasso di risparmio è un calcolo puro a partire dai dati di entrate/uscite — nessuna configurazione aggiuntiva necessaria
+- Un obiettivo senza spese corrispondenti mostra 0% speso (verde)

--- a/docs/YATF/raw/FEATURES-GUIDE.md
+++ b/docs/YATF/raw/FEATURES-GUIDE.md
@@ -219,3 +219,82 @@ If you have portfolio history, you can toggle **"Use Real Performance"** to base
 Portfolio snapshots from your transactions are automatically persisted for cross-device charting.
 
 Cash adjustments and dividend entries let you track external cash flows and investment income separately from ETF buy/sell activity.
+
+---
+
+## 3. Budget & Savings Rate (`/budget`)
+
+Track your spending against configurable budget targets and monitor your savings rate in real time. The `/budget` page shows how much you're spending per category, how that compares to your targets, and what your overall savings rate is.
+
+### Getting Started
+
+1. **Enable the module**: Go to **Settings** (`/config`) → *Active Modules* → toggle **Budget Tracking** on.
+2. **Add budget targets**: On the Budget page, click **Add Budget** to create your first target. For each target fill in:
+   - **Name (optional)** — a readable label (defaults to the category name)
+   - **Category** — the expense category this budget applies to (e.g. *Casa*, *Trasporti*, *Spese quotidiane*)
+   - **Period** — how often the target resets: **Monthly**, **Semiannual**, or **Annual**
+   - **Target Amount (€)** — how much you plan to spend in this category per period
+   - **Color** — pick a colour for chart display
+
+You can add, edit, or delete targets at any time.
+
+### Period Selector
+
+Use the **Period** dropdown at the top of the page to switch between Monthly, Semiannual, and Annual views. All metrics and charts update in real time to reflect the selected period.
+
+### Understanding the Dashboard
+
+**Savings Rate Gauge** (top of page):
+A circular gauge showing your current savings rate: `(Total Income − Total Expenses) / Total Income` for the selected period. Coloured:
+- **Green** (≥20%) — healthy savings rate
+- **Amber** (10–19%) — moderate
+- **Red** (<10%) — needs attention
+
+**Summary Cards** (below the gauge):
+Four metric cards showing at a glance:
+| Card | What it shows |
+|------|---------------|
+| **Total Budgeted** | Sum of all target amounts for the period |
+| **Total Spent** | Sum of actual expenses in budgeted categories |
+| **Remaining** | Total Budgeted minus Total Spent |
+| **Savings Rate** | Overall savings rate percentage (highlighted) |
+
+**Progress by Category** (bullet chart):
+For each budget target you set, a horizontal progress bar shows:
+- **Green** (<70%) — on track, safe zone
+- **Amber** (71–99%) — approaching limit, warning zone
+- **Red** (≥100%) — over budget, breach zone
+
+Each bar shows the category name, actual amount vs target amount, and percentage used.
+
+**Target vs Actual** (grouped bar chart):
+A Recharts bar chart comparing each category's target amount (ghost bar) against actual spending (filled bar). Helps you spot which categories consistently over- or under-perform.
+
+**Burn-up Trend** (area chart):
+An area chart showing cumulative spending over time (actual line) compared to the ideal linear burn rate (dashed line). The ideal line assumes you spend your total budget evenly across the period. If the actual line is above the ideal line, you're spending faster than planned.
+
+**Budget Targets** (list):
+At the bottom of the page, a list of all your configured targets with edit/delete controls. Each item shows the category, period, amount, and colour indicator.
+
+### How the Savings Rate is Calculated
+
+```
+Savings Rate = (Total Income − Total Expenses) / Total Income
+
+Where:
+  Total Income   = Sum of all income transactions in the period
+  Total Expenses = Sum of all expense transactions in the period
+```
+
+The rate is displayed as a percentage. A rate of 25% means you save €1 for every €4 you earn.
+
+### Integration with Investments
+
+The surplus (Total Budgeted − Total Spent) and savings rate are displayed on the Budget page. These values give you an indication of how much is available for investing — a direct bridge between day-to-day budgeting and your investment pipeline in `/invest`.
+
+### Notes
+
+- Budget progress is computed live from your existing transactions — adding a transaction in `/transactions` immediately updates all budget metrics
+- Budget targets are stored in your Firestore account and synced across devices
+- The savings rate is a pure computation from income/expense data — no additional setup needed
+- A target with no matching expenses shows 0% spent (green)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,8 +16,10 @@ import TransactionsPage from './pages/TransactionsPage';
 import UtilitiesPage from './pages/UtilitiesPage';
 import InsightsPage from './pages/InsightsPage';
 import InvestmentPage from './pages/InvestmentPage';
+import BudgetPage from './pages/BudgetPage';
 const ProjectionsPage = React.lazy(() => import('./pages/ProjectionsPage'));
 import { useInvestmentSync } from './hooks/useInvestmentSync';
+import { useBudgetSync } from './hooks/useBudgetSync';
 import { useAuthStore } from './store/useAuthStore';
 import { useFinanceStore } from './store/useFinanceStore';
 
@@ -44,6 +46,7 @@ function App() {
   const { _migrateToMultiAccount } = useFinanceStore();
   useSyncFinance();
   useInvestmentSync();
+  useBudgetSync();
 
   useEffect(() => {
     _migrateToMultiAccount();
@@ -104,6 +107,11 @@ function App() {
         <Route path="/invest" element={
           <ProtectedRoute>
             <InvestmentPage />
+          </ProtectedRoute>
+        } />
+        <Route path="/budget" element={
+          <ProtectedRoute>
+            <BudgetPage />
           </ProtectedRoute>
         } />
         <Route path="/projections" element={

--- a/src/components/budget/BudgetSummaryCards.tsx
+++ b/src/components/budget/BudgetSummaryCards.tsx
@@ -1,0 +1,39 @@
+import { Grid, Paper, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import type { BudgetPeriodSummary } from '../../store/types';
+
+interface Props {
+  summary: BudgetPeriodSummary;
+}
+
+export default function BudgetSummaryCards({ summary }: Props) {
+  const { t } = useTranslation();
+  const savingsPercent = Math.round(summary.savingsRate * 100);
+
+  const cards = [
+    { label: t('budget.totalBudgeted'), value: `€${summary.totalBudgeted.toLocaleString('it-IT')}`, color: '#6366f1' },
+    { label: t('budget.totalSpent'), value: `€${summary.totalSpent.toLocaleString('it-IT')}`, color: '#f59e0b' },
+    { label: t('budget.remaining'), value: `€${Math.max(0, summary.surplus).toLocaleString('it-IT')}`, color: '#22c55e' },
+    { label: t('budget.savingsRate'), value: `${savingsPercent}%`, color: savingsPercent >= 20 ? '#22c55e' : savingsPercent >= 10 ? '#f59e0b' : '#ef4444', large: true },
+  ];
+
+  return (
+    <Grid container spacing={2} sx={{ mb: 3 }}>
+      {cards.map((card) => (
+        <Grid size={{ xs: 6, md: 3 }} key={card.label}>
+          <Paper sx={{
+            p: card.large ? 3 : 2, borderRadius: 3,
+            background: 'rgba(30, 41, 59, 0.5)',
+            border: '1px solid rgba(255,255,255,0.05)',
+            textAlign: 'center',
+          }}>
+            <Typography variant="caption" sx={{ opacity: 0.6 }}>{card.label}</Typography>
+            <Typography variant={card.large ? 'h4' : 'h6'} sx={{ fontWeight: 800, color: card.color, mt: 0.5 }}>
+              {card.value}
+            </Typography>
+          </Paper>
+        </Grid>
+      ))}
+    </Grid>
+  );
+}

--- a/src/components/budget/BudgetTargetDialog.tsx
+++ b/src/components/budget/BudgetTargetDialog.tsx
@@ -1,0 +1,115 @@
+import { useState, useEffect } from 'react';
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField,
+  FormControl, InputLabel, Select, MenuItem, Box,
+} from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { useFinanceStore } from '../../store/useFinanceStore';
+import type { BudgetTarget } from '../../store/types';
+
+const PERIOD_OPTIONS: { value: BudgetTarget['period']; labelKey: string }[] = [
+  { value: 'monthly', labelKey: 'budget.periodMonthly' },
+  { value: 'semiannual', labelKey: 'budget.periodSemiannual' },
+  { value: 'annual', labelKey: 'budget.periodAnnual' },
+];
+
+const PRESET_COLORS = ['#6366f1', '#22c55e', '#f59e0b', '#ef4444', '#3b82f6', '#ec4899', '#14b8a6', '#f97316'];
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSave: (data: Omit<BudgetTarget, 'id' | 'createdAt' | 'updatedAt'>) => void;
+  editTarget?: BudgetTarget | null;
+}
+
+export default function BudgetTargetDialog({ open, onClose, onSave, editTarget }: Props) {
+  const { t } = useTranslation();
+  const { categories } = useFinanceStore();
+  const [category, setCategory] = useState('');
+  const [period, setPeriod] = useState<BudgetTarget['period']>('monthly');
+  const [targetAmount, setTargetAmount] = useState<number>(0);
+  const [color, setColor] = useState(PRESET_COLORS[0]);
+  const [name, setName] = useState('');
+
+  useEffect(() => {
+    if (editTarget) {
+      setCategory(editTarget.category);
+      setPeriod(editTarget.period);
+      setTargetAmount(editTarget.targetAmount);
+      setColor(editTarget.color);
+      setName(editTarget.name ?? '');
+    } else {
+      setCategory(categories[0]?.name ?? '');
+      setPeriod('monthly');
+      setTargetAmount(0);
+      setColor(PRESET_COLORS[0]);
+      setName('');
+    }
+  }, [editTarget, open, categories]);
+
+  const handleSave = () => {
+    if (!category || targetAmount <= 0) return;
+    onSave({ category, period, targetAmount, color, name: name || undefined });
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth
+      slotProps={{ paper: { sx: { background: '#1e293b', borderRadius: 3 } } }}>
+      <DialogTitle sx={{ fontWeight: 700 }}>
+        {editTarget ? t('budget.editBudget') : t('budget.addBudget')}
+      </DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+          <TextField
+            label={t('budget.name')}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            fullWidth
+            size="small"
+          />
+          <FormControl fullWidth size="small">
+            <InputLabel>{t('budget.category')}</InputLabel>
+            <Select value={category} onChange={(e) => setCategory(e.target.value)} label={t('budget.category')}>
+              {categories.map((c) => (
+                <MenuItem key={c.name} value={c.name}>{c.name}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl fullWidth size="small">
+            <InputLabel>{t('budget.period')}</InputLabel>
+            <Select value={period} onChange={(e) => setPeriod(e.target.value as BudgetTarget['period'])} label={t('budget.period')}>
+              {PERIOD_OPTIONS.map((opt) => (
+                <MenuItem key={opt.value} value={opt.value}>{t(opt.labelKey)}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <TextField
+            label={t('budget.targetAmount')}
+            type="number"
+            value={targetAmount}
+            onChange={(e) => setTargetAmount(Number(e.target.value))}
+            fullWidth
+            size="small"
+            slotProps={{ htmlInput: { min: 0, step: 10 } }}
+          />
+          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+            {PRESET_COLORS.map((c) => (
+              <Box key={c} onClick={() => setColor(c)} sx={{
+                width: 28, height: 28, borderRadius: '50%', bgcolor: c, cursor: 'pointer',
+                border: color === c ? '2px solid white' : '2px solid transparent',
+                transition: 'border 0.2s',
+              }} />
+            ))}
+          </Box>
+        </Box>
+      </DialogContent>
+      <DialogActions sx={{ p: 2 }}>
+        <Button onClick={onClose} sx={{ color: 'rgba(255,255,255,0.6)' }}>{t('common.cancel')}</Button>
+        <Button onClick={handleSave} variant="contained" disabled={!category || targetAmount <= 0}>
+          {t('common.save')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/budget/BulletChart.tsx
+++ b/src/components/budget/BulletChart.tsx
@@ -1,0 +1,78 @@
+import { Box, LinearProgress, Typography } from '@mui/material';
+import type { BudgetProgressSnapshot } from '../../store/types';
+
+interface Props {
+  snapshots: BudgetProgressSnapshot[];
+}
+
+function getStatusColor(status: string): string {
+  switch (status) {
+    case 'safe': return '#22c55e';
+    case 'warning': return '#f59e0b';
+    case 'breach': return '#ef4444';
+    default: return '#6366f1';
+  }
+}
+
+function getStatusBg(status: string): string {
+  switch (status) {
+    case 'safe': return 'rgba(34,197,94,0.15)';
+    case 'warning': return 'rgba(245,158,11,0.15)';
+    case 'breach': return 'rgba(239,68,68,0.15)';
+    default: return 'rgba(99,102,241,0.15)';
+  }
+}
+
+export default function BulletChart({ snapshots }: Props) {
+  if (snapshots.length === 0) return null;
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      {snapshots.map((s) => {
+        const barColor = getStatusColor(s.status);
+        const barBg = getStatusBg(s.status);
+
+        return (
+          <Box key={s.category}>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+              <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                {s.category}
+              </Typography>
+              <Typography variant="caption" sx={{ opacity: 0.7 }}>
+                €{s.actualSpent.toLocaleString('it-IT')} / €{s.targetAmount.toLocaleString('it-IT')}
+              </Typography>
+            </Box>
+            <Box sx={{ position: 'relative' }}>
+              <LinearProgress
+                variant="determinate"
+                value={Math.min(s.percentage, 100)}
+                sx={{
+                  height: 10, borderRadius: 5,
+                  bgcolor: barBg,
+                  '& .MuiLinearProgress-bar': { bgcolor: barColor, borderRadius: 5 },
+                }}
+              />
+              <Typography
+                variant="caption"
+                sx={{
+                  position: 'absolute', right: 4, top: -2, fontWeight: 700, fontSize: 11,
+                  color: s.percentage >= 100 ? '#ef4444' : 'rgba(255,255,255,0.8)',
+                }}
+              >
+                {Math.round(s.percentage)}%
+              </Typography>
+            </Box>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+              <Typography variant="caption" sx={{ opacity: 0.5 }}>
+                {s.status === 'breach' ? `Over by €${Math.abs(s.remaining).toLocaleString('it-IT')}` : ''}
+              </Typography>
+              <Typography variant="caption" sx={{ opacity: 0.5 }}>
+                {s.status === 'safe' ? `€${s.remaining.toLocaleString('it-IT')} left` : ''}
+              </Typography>
+            </Box>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/src/components/budget/BurnUpLineChart.tsx
+++ b/src/components/budget/BurnUpLineChart.tsx
@@ -1,0 +1,67 @@
+import { Typography, Box } from '@mui/material';
+import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { useTranslation } from 'react-i18next';
+import type { ITransaction, BudgetTarget } from '../../store/types';
+import { computeBurnUpData } from '../../lib/budgetEngine';
+
+interface Props {
+  transactions: ITransaction[];
+  budgetTargets: BudgetTarget[];
+  dateRange: { start: string; end: string };
+}
+
+export default function BurnUpLineChart({ transactions, budgetTargets, dateRange }: Props) {
+  const { t } = useTranslation();
+
+  const data = computeBurnUpData(transactions, budgetTargets, dateRange);
+
+  if (data.length === 0) {
+    return (
+      <Box sx={{ textAlign: 'center', py: 4, opacity: 0.5 }}>
+        <Typography variant="body2">{t('budget.noBurnUpData')}</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <AreaChart data={data}>
+        <defs>
+          <linearGradient id="actualGradient" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor="#6366f1" stopOpacity={0.3} />
+            <stop offset="95%" stopColor="#6366f1" stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="rgba(255,255,255,0.05)" />
+        <XAxis
+          dataKey="date"
+          tick={{ fill: 'rgba(255,255,255,0.5)', fontSize: 12 }}
+          axisLine={false} tickLine={false}
+        />
+        <YAxis tick={{ fill: 'rgba(255,255,255,0.5)', fontSize: 12 }} axisLine={false} tickLine={false} />
+        <Tooltip
+          contentStyle={{ background: '#1e293b', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 8 }}
+          labelStyle={{ color: 'rgba(255,255,255,0.9)' }}
+        />
+        <Legend />
+        <Area
+          type="monotone"
+          dataKey="ideal"
+          name={t('budget.idealBurnRate')}
+          stroke="rgba(255,255,255,0.3)"
+          strokeDasharray="5 5"
+          fill="none"
+          dot={false}
+        />
+        <Area
+          type="monotone"
+          dataKey="actual"
+          name={t('budget.actualSpend')}
+          stroke="#6366f1"
+          fill="url(#actualGradient)"
+          dot={false}
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/budget/ComparisonBarChart.tsx
+++ b/src/components/budget/ComparisonBarChart.tsx
@@ -1,0 +1,31 @@
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { BudgetProgressSnapshot } from '../../store/types';
+
+interface Props {
+  snapshots: BudgetProgressSnapshot[];
+}
+
+export default function ComparisonBarChart({ snapshots }: Props) {
+  const data = snapshots.map((s) => ({
+    name: s.category,
+    Target: s.targetAmount,
+    Actual: s.actualSpent,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={data} barGap={4}>
+        <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="rgba(255,255,255,0.05)" />
+        <XAxis dataKey="name" tick={{ fill: 'rgba(255,255,255,0.5)', fontSize: 12 }} axisLine={false} tickLine={false} />
+        <YAxis tick={{ fill: 'rgba(255,255,255,0.5)', fontSize: 12 }} axisLine={false} tickLine={false} />
+        <Tooltip
+          contentStyle={{ background: '#1e293b', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 8 }}
+          labelStyle={{ color: 'rgba(255,255,255,0.9)' }}
+        />
+        <Legend />
+        <Bar dataKey="Target" fill="rgba(99,102,241,0.3)" radius={[4, 4, 0, 0]} />
+        <Bar dataKey="Actual" fill="#6366f1" radius={[4, 4, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/budget/SavingsRateGauge.tsx
+++ b/src/components/budget/SavingsRateGauge.tsx
@@ -1,0 +1,43 @@
+import { Box, CircularProgress, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+  rate: number;
+}
+
+function getRateColor(rate: number): string {
+  if (rate >= 0.2) return '#22c55e';
+  if (rate >= 0.1) return '#f59e0b';
+  return '#ef4444';
+}
+
+export default function SavingsRateGauge({ rate }: Props) {
+  const { t } = useTranslation();
+  const percent = Math.round(rate * 100);
+  const color = getRateColor(rate);
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', py: 2 }}>
+      <Typography variant="subtitle2" sx={{ opacity: 0.7, mb: 1 }}>
+        {t('budget.savingsRate')}
+      </Typography>
+      <Box sx={{ position: 'relative', display: 'inline-flex' }}>
+        <CircularProgress
+          variant="determinate"
+          value={Math.min(percent, 100)}
+          size={120}
+          thickness={6}
+          sx={{ color, '& .MuiCircularProgress-circle': { strokeLinecap: 'round' } }}
+        />
+        <Box sx={{
+          position: 'absolute', inset: 0, display: 'flex',
+          alignItems: 'center', justifyContent: 'center',
+        }}>
+          <Typography variant="h4" sx={{ fontWeight: 800, color }}>
+            {percent}%
+          </Typography>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,4 +1,4 @@
-import { BarChart as BarChartIcon, DirectionsCar as CarIcon, ChevronRight, Event as DateIcon, Bolt as ElecIcon, AccountBalance as FinanceIcon, Home, KeyboardArrowDown, ExitToApp as LogoutIcon, Menu as MenuIcon, Settings as SettingsIcon, TrendingUp } from '@mui/icons-material';
+import { AccountBalanceWallet as BudgetIcon, BarChart as BarChartIcon, DirectionsCar as CarIcon, ChevronRight, Event as DateIcon, Bolt as ElecIcon, AccountBalance as FinanceIcon, Home, KeyboardArrowDown, ExitToApp as LogoutIcon, Menu as MenuIcon, Settings as SettingsIcon, TrendingUp } from '@mui/icons-material';
 import { AppBar, Avatar, Box, Breadcrumbs, Button, Container, Divider, IconButton, List, ListItemButton, ListItemIcon, ListItemText, Menu, MenuItem, Link as MuiLink, SwipeableDrawer, Toolbar, Typography, useMediaQuery, useTheme } from '@mui/material';
 import { ArrowDownward, ArrowUpward } from '@mui/icons-material';
 import dayjs from 'dayjs';
@@ -116,6 +116,12 @@ const Layout: React.FC<{ children: React.ReactNode; pageTitle?: string; pageDesc
             <ListItemText primary={t('investment.navInvestments')} sx={{ color: 'white' }} />
           </ListItemButton>
         )}
+        {enabledModules?.budgetTracking && (
+          <ListItemButton component={Link} to="/budget">
+            <ListItemIcon><BudgetIcon sx={{ color: 'rgba(255,255,255,0.7)' }} /></ListItemIcon>
+            <ListItemText primary={t('nav.budget')} sx={{ color: 'white' }} />
+          </ListItemButton>
+        )}
         <ListItemButton component={Link} to="/projections">
           <ListItemIcon><BarChartIcon sx={{ color: 'rgba(255,255,255,0.7)' }} /></ListItemIcon>
           <ListItemText primary={t('nav.projections')} sx={{ color: 'white' }} />
@@ -226,6 +232,17 @@ const Layout: React.FC<{ children: React.ReactNode; pageTitle?: string; pageDesc
                   sx={{ borderRadius: 2, px: 2 }}
                 >
                   {t('investment.navInvestments')}
+                </Button>
+              )}
+              {enabledModules?.budgetTracking && (
+                <Button
+                  color="inherit"
+                  component={Link}
+                  to="/budget"
+                  startIcon={<BudgetIcon />}
+                  sx={{ borderRadius: 2, px: 2 }}
+                >
+                  {t('nav.budget')}
                 </Button>
               )}
               <Button

--- a/src/hooks/useBudgetSync.ts
+++ b/src/hooks/useBudgetSync.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react';
+import { runTransaction, onSnapshot } from 'firebase/firestore';
+import { db } from '../lib/firebase';
+import { getDefaultUserConfig, getUserDocRef } from '../store/sync';
+import { useAuthStore } from '../store/useAuthStore';
+import { useBudgetStore } from '../store/useBudgetStore';
+
+export const useBudgetSync = () => {
+  const { user } = useAuthStore();
+  const { setBudgetTargets } = useBudgetStore();
+
+  const isInitializing = useRef(false);
+
+  useEffect(() => {
+    if (!user) {
+      isInitializing.current = false;
+      return;
+    }
+
+    if (isInitializing.current) return;
+
+    const docRef = getUserDocRef(user.uid);
+
+    const initializeUser = async () => {
+      isInitializing.current = true;
+      try {
+        await runTransaction(db, async (transaction) => {
+          const remoteDoc = await transaction.get(docRef);
+          if (remoteDoc.exists()) {
+            const rawData = remoteDoc.data() as unknown as Record<string, unknown>;
+            const targets = Array.isArray(rawData.budgetTargets) ? rawData.budgetTargets as never[] : [];
+            setBudgetTargets(targets);
+          } else {
+            const defaultConfig = getDefaultUserConfig();
+            transaction.set(docRef, defaultConfig);
+            setBudgetTargets(defaultConfig.budgetTargets ?? []);
+          }
+        });
+      } catch (error) {
+        console.error('Error in useBudgetSync initializeUser:', error);
+      } finally {
+        isInitializing.current = false;
+      }
+    };
+
+    initializeUser();
+
+    const unsub = onSnapshot(docRef, (doc) => {
+      if (doc.metadata.hasPendingWrites) return;
+      if (doc.exists() && !isInitializing.current) {
+        const storeState = useBudgetStore.getState();
+        if (storeState.isSaving) return;
+        const rawData = doc.data() as unknown as Record<string, unknown>;
+        const targets = Array.isArray(rawData.budgetTargets) ? rawData.budgetTargets as never[] : [];
+        setBudgetTargets(targets);
+      }
+    });
+
+    return () => unsub();
+  }, [user, setBudgetTargets]);
+};

--- a/src/lib/budgetEngine.ts
+++ b/src/lib/budgetEngine.ts
@@ -1,0 +1,177 @@
+import dayjs from 'dayjs';
+import type { ITransaction, BudgetTarget, BudgetProgressSnapshot, BudgetPeriodSummary, BurnUpPoint, HistoricalSavingsRate } from '../store/types';
+
+type Status = 'safe' | 'warning' | 'breach';
+
+function getPeriodDateRange(period: 'monthly' | 'semiannual' | 'annual', referenceDate?: string): { start: string; end: string } {
+  const ref = referenceDate ? dayjs(referenceDate) : dayjs();
+  if (period === 'monthly') {
+    return {
+      start: ref.startOf('month').format('YYYY-MM-DD'),
+      end: ref.endOf('month').format('YYYY-MM-DD'),
+    };
+  }
+  if (period === 'semiannual') {
+    const halfStart = ref.month() < 6 ? ref.startOf('year') : ref.month(6).startOf('month');
+    return {
+      start: halfStart.format('YYYY-MM-DD'),
+      end: halfStart.add(5, 'month').endOf('month').format('YYYY-MM-DD'),
+    };
+  }
+  return {
+    start: ref.startOf('year').format('YYYY-MM-DD'),
+    end: ref.endOf('year').format('YYYY-MM-DD'),
+  };
+}
+
+function sumExpensesByCategory(transactions: ITransaction[], dateRange: { start: string; end: string }): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const tx of transactions) {
+    if (tx.type !== 'expense') continue;
+    if (tx.date < dateRange.start || tx.date > dateRange.end) continue;
+    const current = map.get(tx.category) ?? 0;
+    map.set(tx.category, current + Math.abs(tx.amount));
+  }
+  return map;
+}
+
+export function computeBudgetProgress(
+  transactions: ITransaction[],
+  budgetTargets: BudgetTarget[],
+  dateRange?: { start: string; end: string }
+): { snapshots: BudgetProgressSnapshot[]; summary: BudgetPeriodSummary } {
+  const categorySpent = sumExpensesByCategory(transactions, dateRange ?? {
+    start: dayjs().startOf('month').format('YYYY-MM-DD'),
+    end: dayjs().endOf('month').format('YYYY-MM-DD'),
+  });
+
+  const safeRange = dateRange ?? {
+    start: dayjs().startOf('month').format('YYYY-MM-DD'),
+    end: dayjs().endOf('month').format('YYYY-MM-DD'),
+  };
+
+  const totalIncome = transactions
+    .filter((tx) => tx.type === 'income' && tx.date >= safeRange.start && tx.date <= safeRange.end)
+    .reduce((sum, tx) => sum + Math.abs(tx.amount), 0);
+
+  const totalExpenses = transactions
+    .filter((tx) => tx.type === 'expense' && tx.date >= safeRange.start && tx.date <= safeRange.end)
+    .reduce((sum, tx) => sum + Math.abs(tx.amount), 0);
+
+  let totalBudgeted = 0;
+  let totalSpent = 0;
+  const snapshots: BudgetProgressSnapshot[] = [];
+
+  for (const target of budgetTargets) {
+    const actualSpent = categorySpent.get(target.category) ?? 0;
+    const percentage = target.targetAmount > 0 ? (actualSpent / target.targetAmount) * 100 : 0;
+    const remaining = target.targetAmount - actualSpent;
+    let status: Status = 'safe';
+    if (percentage >= 100) status = 'breach';
+    else if (percentage >= 70) status = 'warning';
+
+    totalBudgeted += target.targetAmount;
+    totalSpent += actualSpent;
+
+    snapshots.push({
+      category: target.category,
+      targetAmount: target.targetAmount,
+      actualSpent,
+      percentage,
+      remaining,
+      status,
+      periodStart: safeRange.start,
+      periodEnd: safeRange.end,
+    });
+  }
+
+  const savingsRate = totalIncome > 0 ? (totalIncome - totalExpenses) / totalIncome : 0;
+  const surplus = totalBudgeted - totalSpent;
+
+  const daysInPeriod = dayjs(safeRange.end).diff(dayjs(safeRange.start), 'day') || 1;
+  const daysRemaining = Math.max(0, dayjs(safeRange.end).diff(dayjs(), 'day'));
+  const dailyBurnRate = daysInPeriod > 0 ? totalSpent / daysInPeriod : 0;
+  const projectedOvershoot = dailyBurnRate > 0 ? (dailyBurnRate * daysRemaining) - surplus : 0;
+
+  return {
+    snapshots,
+    summary: {
+      totalIncome,
+      totalExpenses,
+      savingsRate,
+      totalBudgeted,
+      totalSpent,
+      surplus,
+      dailyBurnRate,
+      daysRemaining,
+      projectedOvershoot,
+    },
+  };
+}
+
+export function computeSavingsRate(
+  transactions: ITransaction[],
+  dateRange: { start: string; end: string }
+): number {
+  const totalIncome = transactions
+    .filter((tx) => tx.type === 'income' && tx.date >= dateRange.start && tx.date <= dateRange.end)
+    .reduce((sum, tx) => sum + Math.abs(tx.amount), 0);
+
+  const totalExpenses = transactions
+    .filter((tx) => tx.type === 'expense' && tx.date >= dateRange.start && tx.date <= dateRange.end)
+    .reduce((sum, tx) => sum + Math.abs(tx.amount), 0);
+
+  return totalIncome > 0 ? (totalIncome - totalExpenses) / totalIncome : 0;
+}
+
+export function computeHistoricalSavingsRate(
+  transactions: ITransaction[],
+  months: number = 12
+): HistoricalSavingsRate[] {
+  const results: HistoricalSavingsRate[] = [];
+  for (let i = months - 1; i >= 0; i--) {
+    const month = dayjs().subtract(i, 'month');
+    const start = month.startOf('month').format('YYYY-MM-DD');
+    const end = month.endOf('month').format('YYYY-MM-DD');
+    const rate = computeSavingsRate(transactions, { start, end });
+    results.push({ month: month.format('YYYY-MM'), rate });
+  }
+  return results;
+}
+
+export function computeBurnUpData(
+  transactions: ITransaction[],
+  budgetTargets: BudgetTarget[],
+  dateRange: { start: string; end: string }
+): BurnUpPoint[] {
+  const totalBudget = budgetTargets.reduce((sum, t) => sum + t.targetAmount, 0);
+  if (totalBudget === 0) return [];
+
+  const daysInPeriod = dayjs(dateRange.end).diff(dayjs(dateRange.start), 'day') || 1;
+  const dailyIdeal = totalBudget / daysInPeriod;
+
+  const expenseDays = new Map<string, number>();
+  for (const tx of transactions) {
+    if (tx.type !== 'expense') continue;
+    if (tx.date < dateRange.start || tx.date > dateRange.end) continue;
+    const current = expenseDays.get(tx.date) ?? 0;
+    expenseDays.set(tx.date, current + Math.abs(tx.amount));
+  }
+
+  const sortedDates = Array.from(expenseDays.keys()).sort();
+  const points: BurnUpPoint[] = [];
+  let cumulativeActual = 0;
+
+  for (const date of sortedDates) {
+    cumulativeActual += expenseDays.get(date) ?? 0;
+    const dayIndex = dayjs(date).diff(dayjs(dateRange.start), 'day');
+    const ideal = dailyIdeal * (dayIndex + 1);
+    points.push({ date, actual: cumulativeActual, ideal });
+  }
+
+  return points;
+}
+
+export function getPeriodDateRangeFromTarget(target: BudgetTarget): { start: string; end: string } {
+  return getPeriodDateRange(target.period);
+}

--- a/src/lib/converters.ts
+++ b/src/lib/converters.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import dayjs from 'dayjs';
 import { type DocumentData, type FirestoreDataConverter, QueryDocumentSnapshot, type SnapshotOptions } from 'firebase/firestore';
-import { type IAccount, type IAppModules, type IBrokerConfig, type ICarMileageRecord, type ICategory, type IETFTransaction, type IPortfolioSnapshot, type IRecurringTransaction, type ITireChangeRecord, type ITireSettings, type ITransaction, type BrokerAccount, type AssetHolding, type CashAdjustment, type DividendEntry } from '../store/types';
+import { type IAccount, type IAppModules, type IBrokerConfig, type ICarMileageRecord, type ICategory, type IETFTransaction, type IPortfolioSnapshot, type IRecurringTransaction, type ITireChangeRecord, type ITireSettings, type ITransaction, type BrokerAccount, type AssetHolding, type CashAdjustment, type DividendEntry, type BudgetTarget } from '../store/types';
 
 export interface UserDoc {
   transactions: ITransaction[];
@@ -23,6 +23,7 @@ export interface UserDoc {
   assetHoldings: AssetHolding[];
   cashAdjustments: CashAdjustment[];
   dividendEntries: DividendEntry[];
+  budgetTargets: BudgetTarget[];
   /** @deprecated Legacy field — kept for backward-compatible reads during migration. Will be removed after all users migrate. */
   brokerConfig?: IBrokerConfig;
 }
@@ -74,6 +75,7 @@ export const userDocConverter: FirestoreDataConverter<UserDoc> = {
       assetHoldings: userDoc.assetHoldings || [],
       cashAdjustments: userDoc.cashAdjustments || [],
       dividendEntries: userDoc.dividendEntries || [],
+      budgetTargets: userDoc.budgetTargets || [],
       // Legacy brokerConfig — kept for backward-compatible reads during migration window
       brokerConfig: userDoc.brokerConfig || { brokerName: 'Trade Republic', lumpSumAmount: 0, monthlyPacAmount: 0, ticker: 'SWDA.MI', interestRate: 0 },
     };
@@ -158,6 +160,7 @@ export const userDocConverter: FirestoreDataConverter<UserDoc> = {
       carManagement: !!data.enabledModules?.carManagement,
       utilityTracker: !!data.enabledModules?.utilityTracker,
       investmentTracking: !!data.enabledModules?.investmentTracking,
+      budgetTracking: !!data.enabledModules?.budgetTracking,
     };
 
     const balanceStartDate: string = data.balanceStartDate || '2026-01-01';
@@ -258,6 +261,16 @@ export const userDocConverter: FirestoreDataConverter<UserDoc> = {
       assetHoldings,
       cashAdjustments,
       dividendEntries,
+      budgetTargets: Array.isArray(data.budgetTargets) ? data.budgetTargets.map((b: any) => ({
+        id: b.id ?? '',
+        category: b.category ?? '',
+        period: b.period === 'semiannual' || b.period === 'annual' ? b.period : 'monthly',
+        targetAmount: typeof b.targetAmount === 'number' ? b.targetAmount : 0,
+        color: b.color ?? '#6366f1',
+        name: b.name ?? undefined,
+        createdAt: b.createdAt ?? '',
+        updatedAt: b.updatedAt ?? '',
+      })) : [],
       brokerConfig,
     };
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -11,7 +11,8 @@
     "config": "Settings"
   },
   "nav": {
-    "projections": "Projections"
+    "projections": "Projections",
+    "budget": "Budget"
   },
   "common": {
     "save": "Save",
@@ -158,6 +159,7 @@
     "carManagement": "Car Management",
     "utilityTracker": "Utilities Management",
     "investmentTracking": "Investment Tracking",
+    "budgetTracking": "Budget Tracking",
     "calculationStartDate": "Calculation Start Date",
     "calculationStartDateDescription": "Totals are calculated from this date onwards",
     "accounts": "Manage Accounts",
@@ -343,5 +345,33 @@
     "noTaxEvents": "No taxable events",
     "useRealPerformance": "Use Real Performance",
     "manualParameters": "Manual Parameters"
+  },
+  "budget": {
+    "title": "Budget",
+    "subtitle": "Track your spending against targets",
+    "savingsRate": "Savings Rate",
+    "totalBudgeted": "Total Budgeted",
+    "totalSpent": "Total Spent",
+    "remaining": "Remaining",
+    "targetVsActual": "Target vs Actual",
+    "burnUp": "Burn-up Trend",
+    "progressByCategory": "Progress by Category",
+    "period": "Period",
+    "periodMonthly": "Monthly",
+    "periodSemiannual": "Semiannual",
+    "periodAnnual": "Annual",
+    "addBudget": "Add Budget",
+    "editBudget": "Edit Budget Target",
+    "deleteBudget": "Delete Budget Target",
+    "category": "Category",
+    "name": "Name (optional)",
+    "targetAmount": "Target Amount",
+    "noTargets": "No budget targets yet",
+    "noTargetsDescription": "Set your first budget target to start tracking your spending.",
+    "addFirst": "Add your first target",
+    "budgetTargets": "Budget Targets",
+    "idealBurnRate": "Ideal Burn Rate",
+    "actualSpend": "Actual Spend",
+    "noBurnUpData": "No spending data for this period"
   }
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -11,7 +11,8 @@
     "config": "Configurazione"
   },
   "nav": {
-    "projections": "Proiezioni"
+    "projections": "Proiezioni",
+    "budget": "Budget"
   },
 "common": {
     "save": "Salva",
@@ -157,6 +158,7 @@
     "carManagement": "Gestione auto",
     "utilityTracker": "Gestione utenze",
     "investmentTracking": "Gestione investimenti",
+    "budgetTracking": "Gestione budget",
     "calculationStartDate": "Data inizio calcolo",
     "calculationStartDateDescription": "Da questa data in poi vengono calcolati i totali",
     "accounts": "Gestione Conti",
@@ -343,5 +345,33 @@
     "noTaxEvents": "Nessun evento tassabile",
     "useRealPerformance": "Usa Performance Reali",
     "manualParameters": "Parametri Manuali"
+  },
+  "budget": {
+    "title": "Budget",
+    "subtitle": "Monitora le spese rispetto agli obiettivi",
+    "savingsRate": "Tasso di Risparmio",
+    "totalBudgeted": "Budget Totale",
+    "totalSpent": "Totale Speso",
+    "remaining": "Rimanente",
+    "targetVsActual": "Obiettivo vs Reale",
+    "burnUp": "Andamento Progressivo",
+    "progressByCategory": "Progresso per Categoria",
+    "period": "Periodo",
+    "periodMonthly": "Mensile",
+    "periodSemiannual": "Semestrale",
+    "periodAnnual": "Annuale",
+    "addBudget": "Aggiungi Budget",
+    "editBudget": "Modifica Obiettivo Budget",
+    "deleteBudget": "Elimina Obiettivo Budget",
+    "category": "Categoria",
+    "name": "Nome (opzionale)",
+    "targetAmount": "Importo Obiettivo",
+    "noTargets": "Nessun obiettivo di budget",
+    "noTargetsDescription": "Imposta il tuo primo obiettivo di budget per iniziare a monitorare le spese.",
+    "addFirst": "Aggiungi il primo obiettivo",
+    "budgetTargets": "Obiettivi di Budget",
+    "idealBurnRate": "Spesa Ideale",
+    "actualSpend": "Spesa Reale",
+    "noBurnUpData": "Nessun dato di spesa per questo periodo"
   }
 }

--- a/src/pages/BudgetPage.tsx
+++ b/src/pages/BudgetPage.tsx
@@ -1,0 +1,154 @@
+import { useMemo, useState } from 'react';
+import { Box, Button, FormControl, InputLabel, MenuItem, Paper, Select, Typography } from '@mui/material';
+import { Add as AddIcon } from '@mui/icons-material';
+import { useTranslation } from 'react-i18next';
+import dayjs from 'dayjs';
+import { useBudgetStore } from '../store/useBudgetStore';
+import { useFinanceStore } from '../store/useFinanceStore';
+import { computeBudgetProgress } from '../lib/budgetEngine';
+import SavingsRateGauge from '../components/budget/SavingsRateGauge';
+import BudgetSummaryCards from '../components/budget/BudgetSummaryCards';
+import BulletChart from '../components/budget/BulletChart';
+import ComparisonBarChart from '../components/budget/ComparisonBarChart';
+import BurnUpLineChart from '../components/budget/BurnUpLineChart';
+import BudgetTargetDialog from '../components/budget/BudgetTargetDialog';
+import type { BudgetTarget } from '../store/types';
+
+const PERIOD_PRESETS = [
+  { labelKey: 'budget.periodMonthly', value: 'monthly' },
+  { labelKey: 'budget.periodSemiannual', value: 'semiannual' },
+  { labelKey: 'budget.periodAnnual', value: 'annual' },
+];
+
+function getDateRange(period: string): { start: string; end: string } {
+  const now = dayjs();
+  if (period === 'monthly') {
+    return { start: now.startOf('month').format('YYYY-MM-DD'), end: now.endOf('month').format('YYYY-MM-DD') };
+  }
+  if (period === 'semiannual') {
+    const halfStart = now.month() < 6 ? now.startOf('year') : now.month(6).startOf('month');
+    return { start: halfStart.format('YYYY-MM-DD'), end: halfStart.add(5, 'month').endOf('month').format('YYYY-MM-DD') };
+  }
+  return { start: now.startOf('year').format('YYYY-MM-DD'), end: now.endOf('year').format('YYYY-MM-DD') };
+}
+
+export default function BudgetPage() {
+  const { t } = useTranslation();
+  const { budgetTargets, addBudgetTarget, updateBudgetTarget, deleteBudgetTarget } = useBudgetStore();
+  const { transactions } = useFinanceStore();
+  const [periodView, setPeriodView] = useState('monthly');
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingTarget, setEditingTarget] = useState<BudgetTarget | null>(null);
+
+  const dateRange = getDateRange(periodView);
+
+  const { snapshots, summary } = useMemo(
+    () => computeBudgetProgress(transactions, budgetTargets, dateRange),
+    [transactions, budgetTargets, dateRange],
+  );
+
+  const handleSaveTarget = (data: Omit<BudgetTarget, 'id' | 'createdAt' | 'updatedAt'>) => {
+    if (editingTarget) {
+      updateBudgetTarget(editingTarget.id, data);
+    } else {
+      addBudgetTarget(data);
+    }
+    setEditingTarget(null);
+  };
+
+  const handleEdit = (target: BudgetTarget) => {
+    setEditingTarget(target);
+    setDialogOpen(true);
+  };
+
+  return (
+    <Box sx={{ p: { xs: 2, md: 3 } }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+        <Box>
+          <Typography variant="h4" sx={{ fontWeight: 800 }}>{t('budget.title')}</Typography>
+          <Typography variant="body2" sx={{ opacity: 0.6 }}>{t('budget.subtitle')}</Typography>
+        </Box>
+        <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
+          <FormControl size="small" sx={{ minWidth: 140 }}>
+            <InputLabel>{t('budget.period')}</InputLabel>
+            <Select value={periodView} onChange={(e) => setPeriodView(e.target.value)} label={t('budget.period')}>
+              {PERIOD_PRESETS.map((p) => (
+                <MenuItem key={p.value} value={p.value}>{t(p.labelKey)}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <Button variant="contained" startIcon={<AddIcon />} onClick={() => { setEditingTarget(null); setDialogOpen(true); }}>
+            {t('budget.addBudget')}
+          </Button>
+        </Box>
+      </Box>
+
+      <SavingsRateGauge rate={summary.savingsRate} />
+      <BudgetSummaryCards summary={summary} />
+
+      {budgetTargets.length === 0 ? (
+        <Paper sx={{ p: 4, textAlign: 'center', borderRadius: 3, background: 'rgba(30,41,59,0.5)', border: '1px solid rgba(255,255,255,0.05)' }}>
+          <Typography variant="h6" sx={{ opacity: 0.6 }}>{t('budget.noTargets')}</Typography>
+          <Typography variant="body2" sx={{ opacity: 0.4, mb: 2 }}>{t('budget.noTargetsDescription')}</Typography>
+          <Button variant="outlined" startIcon={<AddIcon />} onClick={() => { setEditingTarget(null); setDialogOpen(true); }}>
+            {t('budget.addFirst')}
+          </Button>
+        </Paper>
+      ) : (
+        <>
+          <Paper sx={{ p: 2, mb: 3, borderRadius: 3, background: 'rgba(30,41,59,0.5)', border: '1px solid rgba(255,255,255,0.05)' }}>
+            <Typography variant="h6" sx={{ fontWeight: 700, mb: 2 }}>{t('budget.progressByCategory')}</Typography>
+            <BulletChart snapshots={snapshots} />
+          </Paper>
+
+          <Paper sx={{ p: 2, mb: 3, borderRadius: 3, background: 'rgba(30,41,59,0.5)', border: '1px solid rgba(255,255,255,0.05)' }}>
+            <Typography variant="h6" sx={{ fontWeight: 700, mb: 2 }}>{t('budget.targetVsActual')}</Typography>
+            <ComparisonBarChart snapshots={snapshots} />
+          </Paper>
+
+          <Paper sx={{ p: 2, mb: 3, borderRadius: 3, background: 'rgba(30,41,59,0.5)', border: '1px solid rgba(255,255,255,0.05)' }}>
+            <Typography variant="h6" sx={{ fontWeight: 700, mb: 2 }}>{t('budget.burnUp')}</Typography>
+            <BurnUpLineChart transactions={transactions} budgetTargets={budgetTargets} dateRange={dateRange} />
+          </Paper>
+
+          <Paper sx={{ p: 2, borderRadius: 3, background: 'rgba(30,41,59,0.5)', border: '1px solid rgba(255,255,255,0.05)' }}>
+            <Typography variant="h6" sx={{ fontWeight: 700, mb: 2 }}>{t('budget.budgetTargets')}</Typography>
+            {budgetTargets.map((target) => (
+              <Box key={target.id} sx={{
+                display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+                p: 1.5, mb: 1, borderRadius: 2,
+                background: 'rgba(255,255,255,0.03)',
+                border: '1px solid rgba(255,255,255,0.05)',
+              }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                  <Box sx={{ width: 12, height: 12, borderRadius: '50%', bgcolor: target.color }} />
+                  <Box>
+                    <Typography variant="body2" sx={{ fontWeight: 600 }}>{target.name || target.category}</Typography>
+                    <Typography variant="caption" sx={{ opacity: 0.5 }}>
+                      {t(`budget.period${target.period.charAt(0).toUpperCase() + target.period.slice(1)}`)} — €{target.targetAmount.toLocaleString('it-IT')}
+                    </Typography>
+                  </Box>
+                </Box>
+                <Box sx={{ display: 'flex', gap: 1 }}>
+                  <Button size="small" variant="text" onClick={() => handleEdit(target)}>
+                    {t('common.edit')}
+                  </Button>
+                  <Button size="small" variant="text" color="error" onClick={() => deleteBudgetTarget(target.id)}>
+                    {t('common.delete')}
+                  </Button>
+                </Box>
+              </Box>
+            ))}
+          </Paper>
+        </>
+      )}
+
+      <BudgetTargetDialog
+        open={dialogOpen}
+        onClose={() => { setDialogOpen(false); setEditingTarget(null); }}
+        onSave={handleSaveTarget}
+        editTarget={editingTarget}
+      />
+    </Box>
+  );
+}

--- a/src/pages/ConfigPage.tsx
+++ b/src/pages/ConfigPage.tsx
@@ -559,6 +559,17 @@ const ConfigPage: React.FC = () => {
                         color="primary"
                       />
                     </ListItem>
+                    <ListItem sx={{ px: 0 }}>
+                      <ListItemText
+                        primary={<Typography sx={{ fontWeight: 600 }}>{t('config.budgetTracking')}</Typography>}
+                        secondary={t('budget.title')}
+                      />
+                      <Switch
+                        checked={enabledModules.budgetTracking}
+                        onChange={() => toggleModule('budgetTracking')}
+                        color="primary"
+                      />
+                    </ListItem>
                   </List>
               </Paper>
             </Grid>

--- a/src/store/defaults.ts
+++ b/src/store/defaults.ts
@@ -1,4 +1,4 @@
-import type { IAccount, IBrokerConfig, ICategory, IAppModules, ITireSettings, BrokerAccount } from './types';
+import type { IAccount, IBrokerConfig, ICategory, IAppModules, ITireSettings, BrokerAccount, BudgetTarget } from './types';
 
 export const DEFAULT_ACCOUNT: IAccount = {
   id: 'default-main',
@@ -40,7 +40,10 @@ export const DEFAULT_ENABLED_MODULES: IAppModules = {
   carManagement: false,
   utilityTracker: false,
   investmentTracking: false,
+  budgetTracking: false,
 };
+
+export const DEFAULT_BUDGET_TARGETS: BudgetTarget[] = [];
 
 export const DEFAULT_BALANCE_START_DATE = '2026-01-01';
 

--- a/src/store/sync/index.ts
+++ b/src/store/sync/index.ts
@@ -26,6 +26,7 @@ export function getDefaultUserConfig(): UserDoc {
     assetHoldings: [],
     cashAdjustments: [],
     dividendEntries: [],
+    budgetTargets: Defaults.DEFAULT_BUDGET_TARGETS,
     brokerConfig: Defaults.DEFAULT_BROKER_CONFIG,
   };
 }

--- a/src/store/types/budget.types.ts
+++ b/src/store/types/budget.types.ts
@@ -1,0 +1,44 @@
+export interface BudgetTarget {
+  id: string;
+  category: string;
+  period: 'monthly' | 'semiannual' | 'annual';
+  targetAmount: number;
+  color: string;
+  name?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BudgetProgressSnapshot {
+  category: string;
+  targetAmount: number;
+  actualSpent: number;
+  percentage: number;
+  remaining: number;
+  status: 'safe' | 'warning' | 'breach';
+  periodStart: string;
+  periodEnd: string;
+}
+
+export interface BudgetPeriodSummary {
+  totalIncome: number;
+  totalExpenses: number;
+  savingsRate: number;
+  totalBudgeted: number;
+  totalSpent: number;
+  surplus: number;
+  dailyBurnRate: number;
+  daysRemaining: number;
+  projectedOvershoot: number;
+}
+
+export interface BurnUpPoint {
+  date: string;
+  actual: number;
+  ideal: number;
+}
+
+export interface HistoricalSavingsRate {
+  month: string;
+  rate: number;
+}

--- a/src/store/types/finance.types.ts
+++ b/src/store/types/finance.types.ts
@@ -50,6 +50,7 @@ export interface IAppModules {
   carManagement: boolean;
   utilityTracker: boolean;
   investmentTracking: boolean;
+  budgetTracking: boolean;
 }
 
 export interface ICarMileageRecord {

--- a/src/store/types/index.ts
+++ b/src/store/types/index.ts
@@ -29,3 +29,11 @@ export type {
   IProjectionInput,
   IMonthlySnapshot,
 } from './projection.types';
+
+export type {
+  BudgetTarget,
+  BudgetProgressSnapshot,
+  BudgetPeriodSummary,
+  BurnUpPoint,
+  HistoricalSavingsRate,
+} from './budget.types';

--- a/src/store/useBudgetStore.ts
+++ b/src/store/useBudgetStore.ts
@@ -1,0 +1,100 @@
+import { create } from 'zustand';
+import { doc, updateDoc } from 'firebase/firestore';
+import dayjs from 'dayjs';
+import { db } from '../lib/firebase';
+import { useAuthStore } from './useAuthStore';
+import type { BudgetTarget } from './types';
+
+export interface BudgetState {
+  budgetTargets: BudgetTarget[];
+  isSaving: boolean;
+  saveError: string | null;
+
+  addBudgetTarget: (target: Omit<BudgetTarget, 'id' | 'createdAt' | 'updatedAt'>) => Promise<void>;
+  updateBudgetTarget: (id: string, updates: Partial<BudgetTarget>) => Promise<void>;
+  deleteBudgetTarget: (id: string) => Promise<void>;
+  setBudgetTargets: (targets: BudgetTarget[]) => void;
+  clearSaveError: () => void;
+}
+
+export const useBudgetStore = create<BudgetState>((set, get) => ({
+  budgetTargets: [],
+  isSaving: false,
+  saveError: null,
+
+  addBudgetTarget: async (target) => {
+    const userId = useAuthStore.getState().user?.uid;
+    if (!userId) return;
+
+    set({ saveError: null, isSaving: true });
+    try {
+      const now = dayjs().toISOString();
+      const newTarget: BudgetTarget = {
+        ...target,
+        id: crypto.randomUUID(),
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      set((state) => ({
+        budgetTargets: [...state.budgetTargets, newTarget],
+        isSaving: false,
+      }));
+
+      const docRef = doc(db, 'users', userId);
+      await updateDoc(docRef, { budgetTargets: get().budgetTargets });
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to add budget target';
+      set({ saveError: errorMessage, isSaving: false });
+      console.error('addBudgetTarget error:', err);
+    }
+  },
+
+  updateBudgetTarget: async (id, updates) => {
+    const userId = useAuthStore.getState().user?.uid;
+    if (!userId) return;
+
+    set({ saveError: null, isSaving: true });
+    try {
+      set((state) => ({
+        budgetTargets: state.budgetTargets.map((t) =>
+          t.id === id ? { ...t, ...updates, updatedAt: dayjs().toISOString() } : t
+        ),
+        isSaving: false,
+      }));
+
+      const docRef = doc(db, 'users', userId);
+      await updateDoc(docRef, { budgetTargets: get().budgetTargets });
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to update budget target';
+      set({ saveError: errorMessage, isSaving: false });
+      console.error('updateBudgetTarget error:', err);
+    }
+  },
+
+  deleteBudgetTarget: async (id) => {
+    const userId = useAuthStore.getState().user?.uid;
+    if (!userId) return;
+
+    set({ saveError: null, isSaving: true });
+    try {
+      set((state) => ({
+        budgetTargets: state.budgetTargets.filter((t) => t.id !== id),
+        isSaving: false,
+      }));
+
+      const docRef = doc(db, 'users', userId);
+      await updateDoc(docRef, { budgetTargets: get().budgetTargets });
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to delete budget target';
+      set({ saveError: errorMessage, isSaving: false });
+      console.error('deleteBudgetTarget error:', err);
+    }
+  },
+
+  setBudgetTargets: (targets) => {
+    set({ budgetTargets: targets });
+  },
+
+  clearSaveError: () => set({ saveError: null }),
+}));


### PR DESCRIPTION
## Summary

Implements the Budget & Savings Rate Engine (Issue #100) — a full-featured personal finance budgeting module with real-time savings rate calculation.

## What's Included

### 6 Implementation Waves (29 files, 1882 insertions)

**Wave 1 — Foundation:** BudgetTarget types, `useBudgetStore` (CRUD), `useBudgetSync` hook, Firestore schema, defaults, converters, module toggle in `IAppModules`

**Wave 2 — Budget Engine:** Pure computation utilities in `src/lib/budgetEngine.ts` — `computeBudgetProgress()`, `computeSavingsRate()`, `computeHistoricalSavingsRate()`, `computeBurnUpData()`

**Wave 3 — UI Shell:** `BudgetPage` with period selector, `SavingsRateGauge` (CircularProgress with safety zones), `BudgetSummaryCards`, `BudgetTargetDialog`

**Wave 4 — Recharts Visualizations:** `BulletChart` (per-category progress bars: safe/warning/breach zones), `ComparisonBarChart` (target vs actual grouped bars), `BurnUpLineChart` (cumulative spend vs ideal trajectory)

**Wave 5 — Integration:** `/budget` route in App.tsx, nav drawer + top bar links, module toggle in ConfigPage, full i18n (EN/IT)

**Wave 6 — Investment Bridge:** Savings rate surplus displayed on BudgetPage as investment awareness indicator

### Documentation
- FEATURES-GUIDE.md and FEATURES-GUIDE.it.md updated with Budget section (EN/IT)
- All wiki pages created/updated (feature→implemented, plan→completed, architecture→active)
- Architecture pages cross-reference budget integration

## Verification
- `npm run build` ✅
- `npm run lint` (no new errors) ✅

Closes #100