### PR TITLE
chore: release development into main

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -21,3 +21,5 @@ jobs:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_MYFINANCETRACKER_B257E }}
           projectId: myfinancetracker-b257e
+          channelId: pr${{ github.event.number }}
+          expires: 30d

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -16,24 +16,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - name: Check for source code changes
         id: check
         run: |
-          BASE="origin/${{ github.base_ref }}"
-          git fetch origin ${{ github.base_ref }}
-          CHANGED=$(git diff --name-only $BASE...HEAD -- src/ package.json package-lock.json tsconfig.json tsconfig.app.json vite.config.ts index.html firebase.json .nvmrc 2>/dev/null || echo "")
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          CHANGED=$(git diff --name-only "$BASE_SHA"...HEAD -- src/ package.json package-lock.json tsconfig.json tsconfig.app.json vite.config.ts index.html firebase.json .nvmrc 2>/dev/null || true)
           if [ -z "$CHANGED" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "No source code changes — skipping preview deployment."
           else
-            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "skip=false" >> "$GITHUB_OUTPUT"
             echo "Changed files:"
             echo "$CHANGED"
           fi
       - run: npm ci && npm run build
         if: steps.check.outputs.skip != 'true'
       - uses: FirebaseExtended/action-hosting-deploy@v0
+        continue-on-error: true
         if: steps.check.outputs.skip != 'true'
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -15,8 +15,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for source code changes
+        id: check
+        run: |
+          BASE="origin/${{ github.base_ref }}"
+          git fetch origin ${{ github.base_ref }}
+          CHANGED=$(git diff --name-only $BASE...HEAD -- src/ package.json package-lock.json tsconfig.json tsconfig.app.json vite.config.ts index.html firebase.json .nvmrc 2>/dev/null || echo "")
+          if [ -z "$CHANGED" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "No source code changes — skipping preview deployment."
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "Changed files:"
+            echo "$CHANGED"
+          fi
       - run: npm ci && npm run build
+        if: steps.check.outputs.skip != 'true'
       - uses: FirebaseExtended/action-hosting-deploy@v0
+        if: steps.check.outputs.skip != 'true'
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_MYFINANCETRACKER_B257E }}

--- a/docs/YATF/architecture/concerns-and-tech-debt.md
+++ b/docs/YATF/architecture/concerns-and-tech-debt.md
@@ -35,6 +35,7 @@ related: ["architecture/project-state", "architecture/testing-status", "architec
 | Race condition in `checkRecurring()` | Sync snapshot | ✅ Fixed (isCheckingRecurring flag) |
 | Sync overwrites local edits | Multi-device editing | ✅ Fixed (hasLocalChanges tracking) |
 | Import doesn't validate transaction data | Corrupted backup | ✅ Fixed (Backup.validateBackupData()) |
+| Backup/restore missing budget + investment data (6 entities) | Export/import loses budget config, broker accounts, holdings, cash adjustments, dividends | ✅ Fixed — see [[plans/backup-restore-data-coverage]] |
 | Data loss on category deletion with subcategories | `isSaving: true` stuck | **Open** — store returns early without saving |
 | No error handling for array update conflicts | Rapid clicks, multi-tab | **Open** |
 | Deleting account doesn't clean up related transactions | Orphaned data | **Open** |

--- a/docs/YATF/architecture/project-state.md
+++ b/docs/YATF/architecture/project-state.md
@@ -57,6 +57,10 @@ related: ["plans/roadmap", "architecture/concerns-and-tech-debt", "features/car-
 - ✅ Sync overwrites local edits — added `hasLocalChanges` tracking
 - ✅ Import validation — added `Backup.validateBackupData()`
 
+## Fixed Issues
+
+1. ✅ **Backup/Restore data coverage** — budget targets and full investment data (broker accounts, holdings, cash adjustments, dividends) now included in export/import. See [[plans/backup-restore-data-coverage]].
+
 ## Next Steps
 
 1. Add test suite — Configure Vitest

--- a/docs/YATF/index.md
+++ b/docs/YATF/index.md
@@ -1,7 +1,7 @@
 # Wiki Index
 
-*Last updated: 2026-06-28* (Manual Review #99 — all 7 items implemented)
-*Total pages: 39*
+*Last updated: 2026-06-30* (Backup/restore data coverage audit)
+*Total pages: 40*
 
 ---
 
@@ -39,6 +39,7 @@
 | [[plans/investment-tracking-v3-implementation]] | ✅ V3 implementation: dividend, tax, cash adjustments, performance prefill | [`#98`](https://github.com/AlexDevsTheWeb/myfinance/issues/98) |
 | [[plans/budget-savings-engine-implementation]] | ✅ V4 Budget & Savings Rate implementation: 6 waves, 11 new files, 10 modified | [`#100`](https://github.com/AlexDevsTheWeb/myfinance/issues/100) |
 | [[plans/manual-review-99-implementation]] | ✅ 5-wave plan: bug fixes, padding, account dialog, dashboard charts, sidebar | [`#99`](https://github.com/AlexDevsTheWeb/myfinance/issues/99) |
+| [[plans/backup-restore-data-coverage]] | Plan to add missing budget + investment data to backup/restore | [`raw/101-backup-restore-gaps.md`](raw/101-backup-restore-gaps.md) |
 
 ## Bugs
 

--- a/docs/YATF/log.md
+++ b/docs/YATF/log.md
@@ -222,6 +222,32 @@
 - Updated FEATURES-GUIDE.md and FEATURES-GUIDE.it.md with Budget section
 - Updated index.md and log.md
 
+## [2026-06-30] implement | Backup/Restore | Fixed budget + investment data coverage
+- Implemented fix for 6 missing entities in backup/restore (`budgetTargets`, `brokerAccounts`, `assetHoldings`, `cashAdjustments`, `dividendEntries`, `deletedRecurringInstances`)
+- Updated `src/store/backup/index.ts`:
+  - Extended `BackupPayload` interface with 6 new fields
+  - Updated `createBackup()` to read from actual stores (`useInvestmentStore`, `useBudgetStore`) instead of broken `(state as any)` pattern
+  - Added validation for `budgetTargets`, `brokerAccounts`, `cashAdjustments`, `dividendEntries`
+  - Extended `BackupPreview` summary with new entity counts
+- Updated `src/store/useFinanceStore.ts`:
+  - Extended `importAllData()` to write new fields to Firestore
+  - Added cross-store state restoration for `useBudgetStore` and `useInvestmentStore`
+- Updated `src/pages/ConfigPage.tsx` — preview dialog shows new entity counts
+- Updated `src/store/types/finance.types.ts` — return type uses `BackupPreview`
+- Updated [[plans/backup-restore-data-coverage]] status → **completed**
+- Updated [[architecture/concerns-and-tech-debt]] — marked backup gap as fixed
+- Updated [[architecture/project-state]] — moved backup gap to resolved
+- Updated index.md and log.md
+
+## [2026-06-30] audit | Backup/Restore | Budget + investment data gaps identified
+- Audited backup/restore (`src/store/backup/index.ts`) for budget and investment data coverage
+- **Found:** 6 entities missing from backup/restore — `budgetTargets`, `brokerAccounts`, `assetHoldings`, `cashAdjustments`, `dividendEntries`, `deletedRecurringInstances`
+- Created [[raw/101-backup-restore-gaps.md]] — full gap analysis
+- Created [[plans/backup-restore-data-coverage]] — implementation plan
+- Updated [[architecture/concerns-and-tech-debt]] — added backup coverage gap to Known Bugs
+- Updated [[architecture/project-state]] — added Known Gaps section
+- Updated index.md (40 pages) and log.md
+
 ## [2026-06-28] docs | Guide | V3 features added to FEATURES-GUIDE (EN/IT)
 - Updated `raw/FEATURES-GUIDE.md` — added Cash Adjustments, Dividends, Tax Pocket, and Use Real Performance sections
 - Updated `raw/FEATURES-GUIDE.it.md` — Italian version with same V3 additions

--- a/docs/YATF/plans/backup-restore-data-coverage.md
+++ b/docs/YATF/plans/backup-restore-data-coverage.md
@@ -1,0 +1,73 @@
+---
+title: "Plan: Backup/Restore Data Coverage"
+tags: [plan, backup, budget, investment, needed]
+created: 2026-06-30
+updated: 2026-06-30
+status: planned
+sources: ["raw/101-backup-restore-gaps.md"]
+related: ["architecture/concerns-and-tech-debt", "features/budget-savings-engine", "features/investment-tracking-v3"]
+---
+
+# Plan: Backup/Restore Data Coverage
+
+**Status:** Completed
+**Priority:** High
+
+## Goal
+
+Ensure backup/restore includes all persisted data entities — specifically budget targets and the full investment data model (broker accounts, asset holdings, cash adjustments, dividend entries).
+
+## Missing Entities
+
+| Entity | Store | Backup | Restore | Risk |
+|--------|-------|--------|---------|------|
+| `budgetTargets` | `useBudgetStore` | ❌ | ❌ | Budget config lost on restore |
+| `brokerAccounts` | `useInvestmentStore` | ❌ | ❌ | Broker config lost on restore (only legacy `brokerConfig` saved) |
+| `assetHoldings` | `useInvestmentStore` | ❌ | ❌ | Holdings lost on restore |
+| `cashAdjustments` | `useInvestmentStore` | ❌ | ❌ | Cash adjustments lost on restore |
+| `dividendEntries` | `useInvestmentStore` | ❌ | ❌ | Dividend history lost on restore |
+| `deletedRecurringInstances` | `useFinanceStore` | ❌ | ❌ | Minor — recurring deletions re-appear |
+
+## Changes Required
+
+### 1. `src/store/backup/index.ts`
+
+- Extend `BackupPayload` interface with 6 new optional fields
+- Add validation for `budgetTargets`, `brokerAccounts`, `assetHoldings`, `cashAdjustments`, `dividendEntries`
+- Update `createBackup()` to read from respective stores via cast
+- Extend `BackupPreview.summary` with new entity counts
+- Update `previewBackup()` to include new counts
+
+### 2. `src/store/useFinanceStore.ts`
+
+- Update `importAllData()` Firestore `updateDoc` to write new fields
+- After Firestore write, also set state on `useBudgetStore` and `useInvestmentStore`
+
+### 3. Cross-store restore
+
+`importAllData()` currently only sets state on `useFinanceStore`. Must also:
+
+```
+useBudgetStore.getState().setBudgetTargets(data.budgetTargets ?? [])
+useInvestmentStore.getState().setAll({
+  brokerAccounts: data.brokerAccounts ?? Defaults.DEFAULT_BROKER_ACCOUNTS,
+  assetHoldings: data.assetHoldings ?? [],
+  cashAdjustments: data.cashAdjustments ?? [],
+  dividendEntries: data.dividendEntries ?? [],
+})
+```
+
+## Verification
+
+1. Export backup with budget targets + investment data (broker accounts, holdings, adjustments, dividends)
+2. Inspect JSON — verify all fields present
+3. Restore backup — verify all data intact in UI
+4. Run `npm run build` — verify no type errors
+
+## Related
+
+- [[architecture/concerns-and-tech-debt]] — import/backup fragility noted
+- [[features/budget-savings-engine]] — budget data source
+- [[features/investment-tracking-v3]] — cash adjustments + dividends
+- [[features/multi-broker-architecture]] — broker accounts + holdings
+- Source: [raw/101-backup-restore-gaps.md](raw/101-backup-restore-gaps.md)

--- a/docs/YATF/plans/roadmap.md
+++ b/docs/YATF/plans/roadmap.md
@@ -29,7 +29,7 @@ Personal finance tracker with Firebase Auth + Firestore backend, featuring multi
 ### Phase 04: Backup & Restore
 - **Priority:** High — data disaster protection
 - **Requirements:** Export to JSON, import/restore, preview, valid human-readable format
-- **Plan:** [[plans/04-01-backup-restore]] (not yet created)
+- **Plan:** [[plans/backup-restore-data-coverage]] — audit found 6 missing entities (budget + investment data)
 
 ### Phase 05: Cloud Backup (Google Drive)
 - **Priority:** Medium — convenience feature

--- a/docs/YATF/raw/101-backup-restore-gaps.md
+++ b/docs/YATF/raw/101-backup-restore-gaps.md
@@ -1,0 +1,87 @@
+# Audit: Backup/Restore Missing Data Entities
+
+## Summary
+
+The backup/restore subsystem (`src/store/backup/index.ts`) was built before budget and investment V3 features were added. It does not include these data entities:
+
+### Missing from BackupPayload
+
+| Entity | Store | Field in UserDoc? | Notes |
+|--------|-------|-------------------|-------|
+| `budgetTargets` | `useBudgetStore` | ✅ Yes | No reference in backup/restore at all |
+| `brokerAccounts` | `useInvestmentStore` | ✅ Yes | Missing — old `brokerConfig` included instead |
+| `assetHoldings` | `useInvestmentStore` | ✅ Yes | Missing |
+| `cashAdjustments` | `useInvestmentStore` | ✅ Yes | Missing |
+| `dividendEntries` | `useInvestmentStore` | ✅ Yes | Missing |
+| `deletedRecurringInstances` | `useFinanceStore` | ✅ Yes | Missing (minor — rarely needed) |
+
+### Currently Included (mostly legacy)
+
+| Entity | Backup Payload Field | Status |
+|--------|---------------------|--------|
+| `initialBalance` | ✅ | OK |
+| `accounts` | ✅ | OK |
+| `transactions` | ✅ | OK |
+| `recurringTransactions` | ✅ | OK |
+| `categories` | ✅ | OK |
+| `incomeCategories` | ✅ | OK |
+| `enabledModules` | ✅ | OK |
+| `balanceStartDate` | ✅ | OK |
+| `carMileage` | ✅ | OK |
+| `carInitialMileage` | ✅ | OK |
+| `tireSettings` | ✅ | OK |
+| `tireChanges` | ✅ | OK |
+| `etfTransactions` | ✅ | OK |
+| `portfolioSnapshots` | ✅ | OK |
+| `brokerConfig` | ✅ | Legacy — deprecated, but included |
+
+## Files to Modify
+
+### 1. `src/store/backup/index.ts`
+
+- **`BackupPayload` interface** — add fields:
+  - `budgetTargets?: BudgetTarget[]`
+  - `brokerAccounts?: BrokerAccount[]`
+  - `assetHoldings?: AssetHolding[]`
+  - `cashAdjustments?: CashAdjustment[]`
+  - `dividendEntries?: DividendEntry[]`
+  - `deletedRecurringInstances?: { recurringLinkId: string; date: string }[]`
+
+- **`createBackup()`** — add fields from state (needs `(state as any)` cast or store composition)
+
+- **`validateBackupData()`** — add validation for new fields (basic type checks)
+
+- **`previewBackup()`** — add counts to `BackupPreview.summary` for:
+  - `budgetTargetCount`, `brokerAccountCount`, `assetHoldingCount`, etc.
+
+- **`BackupPreview` interface** — add new count fields to summary
+
+### 2. `src/store/useFinanceStore.ts` — `importAllData()`
+
+- **Firestore write** — add fields to `updateDoc`:
+  - `budgetTargets: data.budgetTargets ?? []`
+  - `brokerAccounts: data.brokerAccounts ?? Defaults.DEFAULT_BROKER_ACCOUNTS`
+  - `assetHoldings: data.assetHoldings ?? []`
+  - `cashAdjustments: data.cashAdjustments ?? []`
+  - `dividendEntries: data.dividendEntries ?? []`
+
+- **Zustand set** — add same fields to local state:
+  - `set({ budgetTargets: data.budgetTargets ?? [] })`
+  - Note: `budgetTargets` lives in `useBudgetStore`, not `useFinanceStore` — need to also call `useBudgetStore.getState().setBudgetTargets()`
+  - Similarly for investment store fields: need to call `useInvestmentStore.getState().setAll()`
+
+## Implementation Order
+
+1. Extend `BackupPayload` with new optional fields
+2. Add validation for new fields in `validateBackupData()`
+3. Add fields to `createBackup()` casting from stores
+4. Extend `BackupPreview` summary with new counts
+5. Add counts to `previewBackup()` return
+6. Update `importAllData()` — write to Firestore + set in respective Zustand stores
+7. Verify: export → download → import → data intact
+
+## Cross-store State Problem
+
+`useFinanceStore.importAllData()` currently only sets state on `useFinanceStore`. After the fix, it must also:
+- Call `useBudgetStore.getState().setBudgetTargets(data.budgetTargets ?? [])`
+- Call `useInvestmentStore.getState().setAll({ brokerAccounts: ..., assetHoldings: ..., cashAdjustments: ..., dividendEntries: ... })`

--- a/src/pages/ConfigPage.tsx
+++ b/src/pages/ConfigPage.tsx
@@ -201,6 +201,11 @@ const ConfigPage: React.FC = () => {
     recurringCount: number;
     categoryCount: number;
     incomeCategoryCount: number;
+    budgetTargetCount: number;
+    brokerAccountCount: number;
+    etfTransactionCount: number;
+    cashAdjustmentCount: number;
+    dividendEntryCount: number;
     exportedAt: string;
   } | null>(null);
   const [importFile, setImportFile] = useState<File | null>(null);
@@ -897,6 +902,21 @@ const ConfigPage: React.FC = () => {
                 </ListItem>
                 <ListItem>
                   <ListItemText primary="Categorie Entrata" secondary={`${previewData.incomeCategoryCount} categorie`} />
+                </ListItem>
+                <ListItem>
+                  <ListItemText primary="Obiettivi Budget" secondary={`${previewData.budgetTargetCount} target`} />
+                </ListItem>
+                <ListItem>
+                  <ListItemText primary="Conti Broker" secondary={`${previewData.brokerAccountCount} conti`} />
+                </ListItem>
+                <ListItem>
+                  <ListItemText primary="Transazioni ETF" secondary={`${previewData.etfTransactionCount} transazioni`} />
+                </ListItem>
+                <ListItem>
+                  <ListItemText primary="Aggiustamenti Cassa" secondary={`${previewData.cashAdjustmentCount} registrazioni`} />
+                </ListItem>
+                <ListItem>
+                  <ListItemText primary="Dividendi/Interessi" secondary={`${previewData.dividendEntryCount} registrazioni`} />
                 </ListItem>
                 <ListItem>
                   <ListItemText primary="Esportato il" secondary={new Date(previewData.exportedAt).toLocaleString('it-IT')} />

--- a/src/store/backup/index.ts
+++ b/src/store/backup/index.ts
@@ -1,6 +1,8 @@
-import type { IBrokerConfig, IETFTransaction, IFinanceState, IPortfolioSnapshot } from '../types';
+import type { IBrokerConfig, IETFTransaction, IFinanceState, IPortfolioSnapshot, BudgetTarget, BrokerAccount, AssetHolding, CashAdjustment, DividendEntry } from '../types';
 import { DEFAULT_BROKER_CONFIG } from '../defaults';
 import { validateTransaction, validateRecurringTransaction } from '../validation';
+import { useInvestmentStore } from '../useInvestmentStore';
+import { useBudgetStore } from '../useBudgetStore';
 
 export interface BackupValidationError {
   type: 'transaction' | 'recurring' | 'account' | 'category' | 'field';
@@ -80,6 +82,50 @@ export function validateBackupData(data: BackupPayload): BackupValidationResult 
     }
   }
 
+  if (data.budgetTargets) {
+    data.budgetTargets.forEach((b, i) => {
+      if (!b.id || typeof b.id !== 'string') {
+        errors.push({ type: 'field', index: i, message: 'Budget target missing valid id' });
+      }
+      if (typeof b.targetAmount !== 'number') {
+        errors.push({ type: 'field', index: i, message: 'Budget target missing valid targetAmount' });
+      }
+    });
+  }
+
+  if (data.brokerAccounts) {
+    data.brokerAccounts.forEach((b, i) => {
+      if (!b.id || typeof b.id !== 'string') {
+        errors.push({ type: 'field', index: i, message: 'Broker account missing valid id' });
+      }
+      if (!b.name || typeof b.name !== 'string') {
+        errors.push({ type: 'field', index: i, message: 'Broker account missing valid name' });
+      }
+    });
+  }
+
+  if (data.cashAdjustments) {
+    data.cashAdjustments.forEach((c, i) => {
+      if (!c.id || typeof c.id !== 'string') {
+        errors.push({ type: 'field', index: i, message: 'Cash adjustment missing valid id' });
+      }
+      if (typeof c.amount !== 'number') {
+        errors.push({ type: 'field', index: i, message: 'Cash adjustment missing valid amount' });
+      }
+    });
+  }
+
+  if (data.dividendEntries) {
+    data.dividendEntries.forEach((d, i) => {
+      if (!d.id || typeof d.id !== 'string') {
+        errors.push({ type: 'field', index: i, message: 'Dividend entry missing valid id' });
+      }
+      if (typeof d.amount !== 'number') {
+        errors.push({ type: 'field', index: i, message: 'Dividend entry missing valid amount' });
+      }
+    });
+  }
+
   return { valid: errors.length === 0, errors };
 }
 
@@ -106,6 +152,12 @@ export interface BackupPayload {
   etfTransactions?: IETFTransaction[];
   portfolioSnapshots?: IPortfolioSnapshot[];
   brokerConfig?: IBrokerConfig;
+  budgetTargets?: BudgetTarget[];
+  brokerAccounts?: BrokerAccount[];
+  assetHoldings?: AssetHolding[];
+  cashAdjustments?: CashAdjustment[];
+  dividendEntries?: DividendEntry[];
+  deletedRecurringInstances?: { recurringLinkId: string; date: string }[];
 }
 
 export interface BackupPreview {
@@ -117,11 +169,18 @@ export interface BackupPreview {
     recurringCount: number;
     categoryCount: number;
     incomeCategoryCount: number;
+    budgetTargetCount: number;
+    brokerAccountCount: number;
+    etfTransactionCount: number;
+    cashAdjustmentCount: number;
+    dividendEntryCount: number;
     exportedAt: string;
   } | null;
 }
 
 export function createBackup(state: IFinanceState): BackupData {
+  const investmentState = useInvestmentStore.getState();
+  const budgetState = useBudgetStore.getState();
   return {
     version: '1.0',
     exportedAt: new Date().toISOString(),
@@ -139,9 +198,15 @@ export function createBackup(state: IFinanceState): BackupData {
       carInitialMileage: state.carInitialMileage,
       tireSettings: state.tireSettings,
       tireChanges: state.tireChanges,
-      etfTransactions: (state as any).etfTransactions ?? [],
-      portfolioSnapshots: (state as any).portfolioSnapshots ?? [],
-      brokerConfig: (state as any).brokerConfig ?? DEFAULT_BROKER_CONFIG,
+      etfTransactions: investmentState.etfTransactions,
+      portfolioSnapshots: investmentState.portfolioSnapshots,
+      brokerConfig: investmentState.brokerConfig ?? DEFAULT_BROKER_CONFIG,
+      budgetTargets: budgetState.budgetTargets,
+      brokerAccounts: investmentState.brokerAccounts,
+      assetHoldings: investmentState.assetHoldings,
+      cashAdjustments: investmentState.cashAdjustments,
+      dividendEntries: investmentState.dividendEntries,
+      deletedRecurringInstances: state.deletedRecurringInstances,
     },
   };
 }
@@ -210,6 +275,11 @@ export async function previewBackup(file: File): Promise<BackupPreview> {
         recurringCount: data?.recurringTransactions?.length ?? 0,
         categoryCount: data?.categories?.length ?? 0,
         incomeCategoryCount: data?.incomeCategories?.length ?? 0,
+        budgetTargetCount: data?.budgetTargets?.length ?? 0,
+        brokerAccountCount: data?.brokerAccounts?.length ?? 0,
+        etfTransactionCount: data?.etfTransactions?.length ?? 0,
+        cashAdjustmentCount: data?.cashAdjustments?.length ?? 0,
+        dividendEntryCount: data?.dividendEntries?.length ?? 0,
         exportedAt,
       },
     };

--- a/src/store/types/finance.types.ts
+++ b/src/store/types/finance.types.ts
@@ -134,18 +134,7 @@ export interface IFinanceState {
   clearSaveError: () => void;
   exportAllData: () => void;
   importAllData: (fileOrData: File | object) => Promise<boolean>;
-  previewBackup: (file: File) => Promise<{
-    valid: boolean;
-    error?: string;
-    summary: {
-      transactionCount: number;
-      accountCount: number;
-      recurringCount: number;
-      categoryCount: number;
-      incomeCategoryCount: number;
-      exportedAt: string;
-    } | null;
-  }>;
+  previewBackup: (file: File) => Promise<import('../../store/backup').BackupPreview>;
 }
 
 // Validation functions moved to ../validation/finance.validation.ts

--- a/src/store/useFinanceStore.ts
+++ b/src/store/useFinanceStore.ts
@@ -4,6 +4,8 @@ import { create } from 'zustand';
 import { db } from '../lib/firebase';
 import i18n from '../lib/i18n';
 import { useAuthStore } from './useAuthStore';
+import { useBudgetStore } from './useBudgetStore';
+import { useInvestmentStore } from './useInvestmentStore';
 import * as Types from './types';
 import * as Validation from './validation';
 import * as Sanitization from './sanitization';
@@ -101,18 +103,7 @@ interface FinanceState {
   clearSaveError: () => void;
   exportAllData: () => void;
   importAllData: (fileOrData: File | object) => Promise<boolean>;
-  previewBackup: (file: File) => Promise<{
-    valid: boolean;
-    error?: string;
-    summary: {
-      transactionCount: number;
-      accountCount: number;
-      recurringCount: number;
-      categoryCount: number;
-      incomeCategoryCount: number;
-      exportedAt: string;
-    } | null;
-  }>;
+  previewBackup: (file: File) => Promise<Backup.BackupPreview>;
 }
 
 export const useFinanceStore = create<FinanceState>()(
@@ -1153,16 +1144,16 @@ setBalanceStartDate: async (date) => {
 
         set({ saveError: null, isSaving: true });
         try {
-          let backup: { version?: string; app?: string; data?: Partial<FinanceState>; state?: Partial<FinanceState> };
+          let backup: { version?: string; app?: string; data?: Record<string, unknown>; state?: Record<string, unknown> };
 
           if (fileOrData instanceof File) {
             const text = await fileOrData.text();
             backup = JSON.parse(text);
           } else {
-            backup = fileOrData as { version?: string; app?: string; data?: Partial<FinanceState>; state?: Partial<FinanceState> };
+            backup = fileOrData as { version?: string; app?: string; data?: Record<string, unknown>; state?: Record<string, unknown> };
           }
 
-          let data: Partial<FinanceState>;
+          let data: Record<string, unknown>;
 
           if (backup.version) {
             if (backup.app !== 'myfinance') {
@@ -1177,43 +1168,67 @@ setBalanceStartDate: async (date) => {
             return false;
           }
 
-          const validation = Backup.validateBackupData(data);
+          const validation = Backup.validateBackupData(data as Backup.BackupPayload);
           if (!validation.valid) {
             const errorMessages = validation.errors.slice(0, 3).map(e => e.message).join(', ');
             set({ saveError: `Invalid backup data: ${errorMessages}`, isSaving: false });
             return false;
           }
 
+          const payload = data as Backup.BackupPayload;
+
           const docRef = doc(db, 'users', userId);
           await updateDoc(docRef, {
-            initialBalance: data.initialBalance ?? 0,
-            accounts: data.accounts ?? Defaults.DEFAULT_ACCOUNTS,
-            transactions: data.transactions ?? [],
-            recurringTransactions: data.recurringTransactions ?? [],
-            categories: data.categories ?? Defaults.DEFAULT_CATEGORIES,
-            incomeCategories: data.incomeCategories ?? Defaults.DEFAULT_INCOME_CATEGORIES,
-            enabledModules: data.enabledModules ?? Defaults.DEFAULT_ENABLED_MODULES,
-            balanceStartDate: data.balanceStartDate ?? Defaults.DEFAULT_BALANCE_START_DATE,
-            carMileage: data.carMileage ?? [],
-            carInitialMileage: data.carInitialMileage ?? 0,
-            tireSettings: data.tireSettings ?? Defaults.DEFAULT_TIRE_SETTINGS,
-            tireChanges: data.tireChanges ?? [],
+            initialBalance: payload.initialBalance ?? 0,
+            accounts: payload.accounts ?? Defaults.DEFAULT_ACCOUNTS,
+            transactions: payload.transactions ?? [],
+            recurringTransactions: payload.recurringTransactions ?? [],
+            categories: payload.categories ?? Defaults.DEFAULT_CATEGORIES,
+            incomeCategories: payload.incomeCategories ?? Defaults.DEFAULT_INCOME_CATEGORIES,
+            enabledModules: payload.enabledModules ?? Defaults.DEFAULT_ENABLED_MODULES,
+            balanceStartDate: payload.balanceStartDate ?? Defaults.DEFAULT_BALANCE_START_DATE,
+            carMileage: payload.carMileage ?? [],
+            carInitialMileage: payload.carInitialMileage ?? 0,
+            tireSettings: payload.tireSettings ?? Defaults.DEFAULT_TIRE_SETTINGS,
+            tireChanges: payload.tireChanges ?? [],
+            etfTransactions: payload.etfTransactions ?? [],
+            portfolioSnapshots: payload.portfolioSnapshots ?? [],
+            brokerConfig: payload.brokerConfig ?? Defaults.DEFAULT_BROKER_CONFIG,
+            budgetTargets: payload.budgetTargets ?? [],
+            brokerAccounts: payload.brokerAccounts ?? Defaults.DEFAULT_BROKER_ACCOUNTS,
+            assetHoldings: payload.assetHoldings ?? [],
+            cashAdjustments: payload.cashAdjustments ?? [],
+            dividendEntries: payload.dividendEntries ?? [],
+            deletedRecurringInstances: payload.deletedRecurringInstances ?? [],
           });
 
           set({
-            initialBalance: data.initialBalance ?? 0,
-            accounts: data.accounts ?? Defaults.DEFAULT_ACCOUNTS,
-            transactions: data.transactions ?? [],
-            recurringTransactions: data.recurringTransactions ?? [],
-            categories: data.categories ?? Defaults.DEFAULT_CATEGORIES,
-            incomeCategories: data.incomeCategories ?? Defaults.DEFAULT_INCOME_CATEGORIES,
-            enabledModules: data.enabledModules ?? Defaults.DEFAULT_ENABLED_MODULES,
-            balanceStartDate: data.balanceStartDate ?? Defaults.DEFAULT_BALANCE_START_DATE,
-            carMileage: data.carMileage ?? [],
-            carInitialMileage: data.carInitialMileage ?? 0,
-            tireSettings: data.tireSettings ?? Defaults.DEFAULT_TIRE_SETTINGS,
-            tireChanges: data.tireChanges ?? [],
+            initialBalance: payload.initialBalance ?? 0,
+            accounts: payload.accounts ?? Defaults.DEFAULT_ACCOUNTS,
+            transactions: payload.transactions ?? [],
+            recurringTransactions: payload.recurringTransactions ?? [],
+            categories: payload.categories ?? Defaults.DEFAULT_CATEGORIES,
+            incomeCategories: payload.incomeCategories ?? Defaults.DEFAULT_INCOME_CATEGORIES,
+            enabledModules: payload.enabledModules ?? Defaults.DEFAULT_ENABLED_MODULES,
+            balanceStartDate: payload.balanceStartDate ?? Defaults.DEFAULT_BALANCE_START_DATE,
+            carMileage: payload.carMileage ?? [],
+            carInitialMileage: payload.carInitialMileage ?? 0,
+            tireSettings: payload.tireSettings ?? Defaults.DEFAULT_TIRE_SETTINGS,
+            tireChanges: payload.tireChanges ?? [],
+            deletedRecurringInstances: payload.deletedRecurringInstances ?? [],
             isSaving: false,
+          });
+
+          useBudgetStore.getState().setBudgetTargets(payload.budgetTargets ?? []);
+
+          useInvestmentStore.getState().setAll({
+            etfTransactions: payload.etfTransactions ?? [],
+            portfolioSnapshots: payload.portfolioSnapshots ?? [],
+            brokerConfig: payload.brokerConfig ?? Defaults.DEFAULT_BROKER_CONFIG,
+            brokerAccounts: payload.brokerAccounts ?? Defaults.DEFAULT_BROKER_ACCOUNTS,
+            assetHoldings: payload.assetHoldings ?? [],
+            cashAdjustments: payload.cashAdjustments ?? [],
+            dividendEntries: payload.dividendEntries ?? [],
           });
 
           return true;


### PR DESCRIPTION
## Release: development → main

Bringing all unreleased changes from development into main:

### Features
- Budget & Savings Rate Engine V4 (#100)
- Investment Tracking V3 — dividends, tax, cash adjustments (#98)
- Manual Review #99 — dashboard redesign, sidebar redesign, bug fixes
- Backup/restore data coverage — budget + investment entities now included

### Commits since last release (v2026.5.0)
94f68a8 fix: add missing budget and investment data to backup/restore
06feb93 docs: update wiki — mark manual review #99 as completed
b7cda29 feat(YATF-99): enrich dashboard with module overview stat cards
cac51e9 feat(YATF-99): sidebar improvements — transactions link, collapsible mode, avatar
212b8d8 feat(YATF-99): Wave 5 — vertical sidebar navigation
1c0d038 feat(YATF-99): Wave 4 — dashboard charts, remove TransactionTable
a6eb836 feat(YATF-99): Wave 3 — Account Detail Dialog
5285b66 feat(YATF-99): Wave 2 — reduce card padding to 12px across all components
b6b7074 feat(YATF-99): Wave 1 — i18n bugfix, hardcoded strings, wiki ingestion
cc2270a fix(development) added exlusion on gitignore
4d9e715 docs: update FEATURES-GUIDE and wiki with Budget module guide + implementation status
53970d4 feat: implement Budget & Savings Rate Engine (V4) — full /budget module
0838521 docs: update FEATURES-GUIDE (EN/IT) with V3 features - adjustments, dividends, tax, performance prefill
11b5b49 feat: implement Dynamic Performance Prefill (Wave 4)
df0e5f0 docs: add CAGR analysis for Dynamic Performance Prefill (Wave 4)
642c10c docs: update index.md with V3 implementation status
e56819c feat: implement V3 dividend, cash adjustment, and tax tracking features
ac18909 docs: add V3 planning artifacts (dividend, tax, performance)
fbbec05 docs: update FEATURES-GUIDE (EN/IT) and wiki with Phase 12 enhancements
508d7da feat(phase-12-investment-tracking-v2): obsidian and wiki
6b1da70 docs: ingest Phase 12 implementation results into wiki — 6 features promoted to implemented, plan completed
f165264 docs: update STATE.md and ROADMAP.md for Phase 12 completion
a55f5fb docs(12-05): complete PAC automation and ticker validation plan
a8519c2 feat(12-05): add ticker validation and integrate into BrokerSettingsModal + i18n
15925ec feat(12-05): create PacConfirmationDialog and add PAC badge to InvestmentPage
17df984 feat(12-05): create usePacAutomation hook with day check and pending transaction generation
b7bdf56 docs(12-04): complete historical snapshots subcollection plan
7d005d4 feat(12-04): add locale keys for snapshot feature
8e14e86 feat(12-04): add Firestore rules for portfolio_history subcollection and store triggers
242e1d0 feat(12-04): create useHistoricalSnapshots hook with subcollection write and daily debounce

Triggering automatic version bump via `version-bump.yml`.