### PR TITLE
Fix: yearly recurring transactions ignore monthOfYear (#142)

### DIFF
--- a/docs/YATF/index.md
+++ b/docs/YATF/index.md
@@ -1,7 +1,7 @@
 # Wiki Index
 
-*Last updated: 2026-07-12* (Go-to-Market Phase 0)
-*Total pages: 56*
+*Last updated: 2026-07-16* (Recurring monthOfYear bug)
+*Total pages: 57*
 
 ---
 
@@ -71,6 +71,7 @@
 |------|---------|---------|
 | [[wiki/bugs/car-statistics-year]] | ✅ Car page "Statistics {year}" shows literal `{year}` | [`#99`](https://github.com/AlexDevsTheWeb/myfinance/issues/99) |
 | [[wiki/bugs/ticker-persistence]] | ✅ BrokerAccount ticker not persisted; PAC uses brokerId as ticker — **fixed** | [`#108`](https://github.com/AlexDevsTheWeb/myfinance/issues/108) |
+| [[wiki/bugs/recurring-transaction-monthofyear]] | 🔴 Yearly recurring transactions ignore `monthOfYear` — generated in wrong month | [`#142`](https://github.com/AlexDevsTheWeb/myfinance/issues/142) |
 
 ## Architecture
 

--- a/docs/YATF/index.md
+++ b/docs/YATF/index.md
@@ -71,7 +71,7 @@
 |------|---------|---------|
 | [[wiki/bugs/car-statistics-year]] | ✅ Car page "Statistics {year}" shows literal `{year}` | [`#99`](https://github.com/AlexDevsTheWeb/myfinance/issues/99) |
 | [[wiki/bugs/ticker-persistence]] | ✅ BrokerAccount ticker not persisted; PAC uses brokerId as ticker — **fixed** | [`#108`](https://github.com/AlexDevsTheWeb/myfinance/issues/108) |
-| [[wiki/bugs/recurring-transaction-monthofyear]] | 🔴 Yearly recurring transactions ignore `monthOfYear` — generated in wrong month | [`#142`](https://github.com/AlexDevsTheWeb/myfinance/issues/142) |
+| [[wiki/bugs/recurring-transaction-monthofyear]] | ✅ Yearly recurring transactions ignore `monthOfYear` — **fixed** | [`#142`](https://github.com/AlexDevsTheWeb/myfinance/issues/142) |
 
 ## Architecture
 

--- a/docs/YATF/log.md
+++ b/docs/YATF/log.md
@@ -423,3 +423,11 @@
 - Secondary issues documented: `lastGeneratedUpTo` not persisted, yearly dedup blocking correct re-gen
 - Updated index.md (57 pages) and log.md
 - Created GitHub issue to track
+
+## [2026-07-16] fix | Bug | #142 — monthOfYear fix implemented
+- Implemented fix in `src/store/useFinanceStore.ts`:
+  - Added `monthOfYear` read in target date computation for yearly transactions (lines 862-868)
+  - Added auto-cleanup of existing wrong-date yearly instances (lines 826-842)
+  - Persists cleanup to Firestore even when no new transactions generated
+- Updated [[wiki/bugs/recurring-transaction-monthofyear]] → status: **fixed**
+- Updated index.md and log.md

--- a/docs/YATF/log.md
+++ b/docs/YATF/log.md
@@ -414,3 +414,12 @@
 - Backfill utility preserved with type-safe legacy read for any remaining cleanup
 - Backup/restore unaffected: backup reads store (sub-collection populated), restore writes to sub-collection via batch
 - Only safe because single user with backups confirmed
+
+## [2026-07-16] bug | Critical | Yearly recurring transactions ignore `monthOfYear` — generated in wrong month
+- Discovered Google One subscription (yearly) invisible in dashboard
+- Root cause: `checkRecurring()` in `src/store/useFinanceStore.ts:837` never reads `payload.monthOfYear`
+- Created [[raw/recurring-transaction-monthofyear/recurring-transaction-monthofyear.md]] — full analysis with root cause, impact, proposed fix
+- Created [[wiki/bugs/recurring-transaction-monthofyear]] — status: **open**, severity: **critical**
+- Secondary issues documented: `lastGeneratedUpTo` not persisted, yearly dedup blocking correct re-gen
+- Updated index.md (57 pages) and log.md
+- Created GitHub issue to track

--- a/docs/YATF/raw/recurring-transaction-monthofyear/recurring-transaction-monthofyear.md
+++ b/docs/YATF/raw/recurring-transaction-monthofyear/recurring-transaction-monthofyear.md
@@ -1,0 +1,120 @@
+# Bug: `monthOfYear` ignored in `checkRecurring()` — Yearly recurrent transactions generated in wrong month
+
+## Discovery
+
+Cannot see Google One subscription (yearly recurrence). Investigation reveals yearly recurrent transactions are generated in the wrong month because `monthOfYear` is never read during generation.
+
+## Affected File
+
+`src/store/useFinanceStore.ts:804-922` — `checkRecurring()`
+
+## Root Cause
+
+At line 837:
+
+```ts
+let targetDate = current.date(payload.dayOfMonth);
+```
+
+This sets the **day** of the target date but keeps whatever **month** `current` is in. The `payload.monthOfYear` field is **never read**.
+
+For yearly transactions, `current` advances by year only, so the month stays fixed to whatever month `current` started in (derived from `startDate` or `balanceStartDate`, whichever is later).
+
+Since `startDate` defaults to `dayjs().format('YYYY-MM-DD')` (today's date at template creation) per `TransactionForm.tsx:325`, a yearly subscription like Google One created in July gets generated as July 15 instead of March 15 — even though `monthOfYear: 3` is stored correctly in Firestore.
+
+## Data Flow
+
+```
+Template: { startDate: "2026-07-16", monthOfYear: 3, dayOfMonth: 15, frequency: "yearly" }
+
+checkRecurring():
+  startFrom = dayjs("2026-07-16")          // July
+  current = July 2026
+  targetDate = current.date(15)             // 2026-07-15  ← WRONG
+  // monthOfYear = 3 should have been used  // should be 2026-03-15
+```
+
+The Dashboard (`DashboardPage.tsx:57-60`) filters by current month only:
+```ts
+const currentDateRange = {
+  start: dayjs().startOf('month').format('YYYY-MM-DD'),
+  end: dayjs().endOf('month').format('YYYY-MM-DD'),
+};
+```
+
+So a yearly transaction generated in the wrong month is invisible in the current month's dashboard.
+
+## Secondary Issues
+
+### 1. `lastGeneratedUpTo` stripped by sanitizer
+
+`src/store/sanitization/recurring.ts:9-22` does not include `lastGeneratedUpTo` in the sanitized output. So on every Firestore write, the field is stripped. On page reload, `checkRecurring()` re-scans from `startDate` instead of resuming from the last generated period.
+
+Already partially addressed by go-to-market Phase 1.3 (#138) — but worth verifying the fix is complete.
+
+### 2. Yearly dedup blocks correct re-generation
+
+At `useFinanceStore.ts:862-864`, the dedup check for yearly transactions matches by **year** only:
+```ts
+if (payload.frequency === 'yearly') {
+    return dayjs(t.date).year() === targetDate.year();
+}
+```
+
+This means: after fixing the `monthOfYear` bug, any existing incorrectly-dated transaction for the same year will block the correct one from being generated.
+
+## Proposed Fix
+
+### Fix 1: Use `monthOfYear` in `checkRecurring()`
+
+In `src/store/useFinanceStore.ts`, after line 837, apply `monthOfYear` for yearly transactions:
+
+```ts
+let targetDate = current.date(payload.dayOfMonth);
+if (payload.frequency === 'yearly' && payload.monthOfYear != null) {
+  targetDate = targetDate.month(payload.monthOfYear - 1);
+}
+```
+
+The existing overflow guard at line 838-840 still applies:
+```ts
+if (targetDate.month() !== current.month()) {
+  targetDate = current.endOf('month');
+}
+```
+
+This must be adjusted: instead of checking against `current.month()`, check against the **intended** month:
+```ts
+const intendedMonth = payload.frequency === 'yearly' && payload.monthOfYear != null
+  ? payload.monthOfYear - 1
+  : current.month();
+if (targetDate.month() !== intendedMonth) {
+  targetDate = dayjs(targetDate).endOf('month');
+}
+```
+
+### Fix 2: Regenerate existing yearly transactions
+
+After Fix 1 lands, existing yearly transactions with wrong dates need to be corrected. Two approaches:
+
+**Approach A — Delete and regenerate:**
+- For each recurring template, delete all generated instances where the year matches but the date is wrong (date doesn't match `monthOfYear`/`dayOfMonth`)
+- Then let `checkRecurring()` regenerate them correctly
+
+**Approach B — Fix dates in place:**
+- Find all transactions with `recurringLinkId` where the date doesn't match the template's `monthOfYear`/`dayOfMonth`
+- Update the date field to the correct month+day (preserving the year)
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/store/useFinanceStore.ts:837-840` | Read `monthOfYear` when computing `targetDate` for yearly transactions |
+| (optional) `src/store/sanitization/recurring.ts` | Verify `lastGeneratedUpTo` is persisted (check Go-to-Market fix) |
+
+## Verification
+
+1. Create a yearly recurring transaction with `monthOfYear` ≠ current month
+2. Navigate to the target month in the dashboard
+3. The generated transaction should appear in the correct month
+4. Monthly recurring transactions should be unaffected

--- a/docs/YATF/wiki/bugs/recurring-transaction-monthofyear.md
+++ b/docs/YATF/wiki/bugs/recurring-transaction-monthofyear.md
@@ -1,0 +1,85 @@
+---
+title: "Yearly recurring transactions ignore monthOfYear — generated in wrong month"
+tags: [bug, recurring, critical, open]
+created: 2026-07-16
+updated: 2026-07-16
+status: open
+severity: critical
+sources: ["raw/recurring-transaction-monthofyear/recurring-transaction-monthofyear.md"]
+related: ["plans/go-to-market", "architecture/system-architecture"]
+---
+
+# Bug: Yearly Recurring Transactions Ignore `monthOfYear`
+
+Status: **open**
+Severity: **critical**
+
+## Symptom
+
+Yearly recurring transactions (e.g., Google One subscription) are generated in the wrong month. The template stores `monthOfYear: 3` (March) correctly, but the generated transaction lands in whatever month `startDate` or `balanceStartDate` falls in — typically the month the template was created.
+
+The transaction is invisible in the current month's dashboard since it was generated for a different month.
+
+## Reproduction
+
+1. Create a yearly recurring transaction with `monthOfYear` set to March and `startDate` in July
+2. Wait for `checkRecurring()` to run (or reload the page)
+3. Observe: the generated transaction has date July 15, not March 15
+4. Navigate to March in the dashboard — no transaction appears
+
+## Root Cause
+
+`src/store/useFinanceStore.ts:837` — `checkRecurring()` never reads `payload.monthOfYear`:
+
+```typescript
+let targetDate = current.date(payload.dayOfMonth);
+// monthOfYear is never read — month stays at current.month()
+```
+
+For yearly transactions, `current` advances by year only, so the month is permanently fixed to the starting month.
+
+## Impact
+
+- Yearly subscriptions (Google One, domain renewals, insurance, etc.) appear in the wrong month
+- Budget tracking, dashboard views, and analysis pages show incorrect monthly data
+- All users with yearly recurring templates are affected
+- The data is stored correctly in Firestore — it's purely a generation-time bug
+
+## Proposed Fix
+
+### Fix 1: Apply `monthOfYear` during target date computation
+
+In `src/store/useFinanceStore.ts`, after line 837:
+
+```typescript
+let targetDate = current.date(payload.dayOfMonth);
+if (payload.frequency === 'yearly' && payload.monthOfYear != null) {
+  targetDate = targetDate.month(payload.monthOfYear - 1);
+}
+```
+
+Adjust the overflow guard to use the **intended month** rather than `current.month()`:
+
+```typescript
+const intendedMonth = payload.frequency === 'yearly' && payload.monthOfYear != null
+  ? payload.monthOfYear - 1
+  : current.month();
+if (targetDate.month() !== intendedMonth) {
+  targetDate = dayjs(targetDate).endOf('month');
+}
+```
+
+### Fix 2: Regenerate existing incorrectly-dated transactions
+
+After Fix 1, existing yearly transactions need correction. Options:
+
+- **A — Delete & regenerate**: Remove generated instances with wrong dates; let `checkRecurring()` recreate them correctly
+- **B — Fix dates in place**: Update transaction dates to match template's `monthOfYear`/`dayOfMonth`
+
+Approach A is cleaner — it works automatically after `checkRecurring()` runs, since the dedup for yearly is by year only. Delete the wrong instances and the next run fills them in correctly.
+
+## Related
+
+- [[wiki/plans/go-to-market]] — Phase 1.3 touched `lastGeneratedUpTo` persistence in recurring code
+- [[wiki/architecture/system-architecture]] — recurring check flow in system architecture
+- Source: [raw/recurring-transaction-monthofyear/recurring-transaction-monthofyear.md](raw/recurring-transaction-monthofyear/recurring-transaction-monthofyear.md)

--- a/docs/YATF/wiki/bugs/recurring-transaction-monthofyear.md
+++ b/docs/YATF/wiki/bugs/recurring-transaction-monthofyear.md
@@ -1,9 +1,9 @@
 ---
 title: "Yearly recurring transactions ignore monthOfYear — generated in wrong month"
-tags: [bug, recurring, critical, open]
+tags: [bug, recurring, critical, fixed]
 created: 2026-07-16
 updated: 2026-07-16
-status: open
+status: fixed
 severity: critical
 sources: ["raw/recurring-transaction-monthofyear/recurring-transaction-monthofyear.md"]
 related: ["plans/go-to-market", "architecture/system-architecture"]
@@ -11,7 +11,7 @@ related: ["plans/go-to-market", "architecture/system-architecture"]
 
 # Bug: Yearly Recurring Transactions Ignore `monthOfYear`
 
-Status: **open**
+Status: **fixed**
 Severity: **critical**
 
 ## Symptom
@@ -45,38 +45,31 @@ For yearly transactions, `current` advances by year only, so the month is perman
 - All users with yearly recurring templates are affected
 - The data is stored correctly in Firestore — it's purely a generation-time bug
 
-## Proposed Fix
+## Implemented Fix (PR #142)
 
-### Fix 1: Apply `monthOfYear` during target date computation
+### File: `src/store/useFinanceStore.ts` — `checkRecurring()`
 
-In `src/store/useFinanceStore.ts`, after line 837:
+**Fix 1 — Apply `monthOfYear` during target date computation** (lines 862-868):
+
+After the existing day-of-month overflow guard, added:
 
 ```typescript
-let targetDate = current.date(payload.dayOfMonth);
 if (payload.frequency === 'yearly' && payload.monthOfYear != null) {
-  targetDate = targetDate.month(payload.monthOfYear - 1);
+  const intendedMonth = payload.monthOfYear - 1;
+  targetDate = targetDate.month(intendedMonth);
+  if (targetDate.month() !== intendedMonth) {
+    targetDate = dayjs(targetDate).date(1).month(intendedMonth).endOf('month');
+  }
 }
 ```
 
-Adjust the overflow guard to use the **intended month** rather than `current.month()`:
+This sets the correct month after the day is applied, then handles day overflow in the new month (e.g., day 31 in a 30-day month snaps to end-of-month).
 
-```typescript
-const intendedMonth = payload.frequency === 'yearly' && payload.monthOfYear != null
-  ? payload.monthOfYear - 1
-  : current.month();
-if (targetDate.month() !== intendedMonth) {
-  targetDate = dayjs(targetDate).endOf('month');
-}
-```
+**Fix 2 — Auto-cleanup of existing wrong instances** (lines 826-842):
 
-### Fix 2: Regenerate existing incorrectly-dated transactions
+Added a one-time cleanup pass at the start of `checkRecurring()` that detects yearly-generated transactions whose date month doesn't match the template's `monthOfYear` and removes them. The subsequent generation loop then recreates them with the correct dates. The cleanup is persisted to Firestore even when no new transactions are generated.
 
-After Fix 1, existing yearly transactions need correction. Options:
-
-- **A — Delete & regenerate**: Remove generated instances with wrong dates; let `checkRecurring()` recreate them correctly
-- **B — Fix dates in place**: Update transaction dates to match template's `monthOfYear`/`dayOfMonth`
-
-Approach A is cleaner — it works automatically after `checkRecurring()` runs, since the dedup for yearly is by year only. Delete the wrong instances and the next run fills them in correctly.
+**Migration**: The fix is transparent — it runs on the next `checkRecurring()` call (page reload or session start). Wrong instances are removed and correct ones generated automatically.
 
 ## Related
 

--- a/src/store/useFinanceStore.ts
+++ b/src/store/useFinanceStore.ts
@@ -813,14 +813,34 @@ setBalanceStartDate: async (date) => {
           if (timeSinceLastCheck < 5000) return;
         }
 
-        set({ saveError: null, isSaving: true, isCheckingRecurring: true });
+          set({ saveError: null, isSaving: true, isCheckingRecurring: true });
         try {
           let hasNewTransactions = false;
+          let hasCleanup = false;
 
           set((state) => {
             const newTransactions: Transaction[] = [];
             const now = dayjs();
             const balanceStart = dayjs(state.balanceStartDate);
+
+            let transactions = state.transactions;
+            const needsCleanup = state.recurringTransactions.some(r => r.frequency === 'yearly' && r.monthOfYear != null);
+            if (needsCleanup) {
+              const wrongIds = new Set(
+                state.transactions
+                  .filter(t => {
+                    if (!t.recurringLinkId) return false;
+                    const r = state.recurringTransactions.find(x => x.id === t.recurringLinkId);
+                    return r?.frequency === 'yearly' && r.monthOfYear != null
+                      && dayjs(t.date).month() !== r.monthOfYear - 1;
+                  })
+                  .map(t => t.id)
+              );
+              if (wrongIds.size > 0) {
+                transactions = state.transactions.filter(t => !wrongIds.has(t.id));
+                hasCleanup = true;
+              }
+            }
 
             const updatedRecurring = state.recurringTransactions.map(payload => {
               const startFrom = payload.lastGeneratedUpTo
@@ -837,6 +857,14 @@ setBalanceStartDate: async (date) => {
                 let targetDate = current.date(payload.dayOfMonth);
                 if (targetDate.month() !== current.month()) {
                   targetDate = current.endOf('month');
+                }
+
+                if (payload.frequency === 'yearly' && payload.monthOfYear != null) {
+                  const intendedMonth = payload.monthOfYear - 1;
+                  targetDate = targetDate.month(intendedMonth);
+                  if (targetDate.month() !== intendedMonth) {
+                    targetDate = dayjs(targetDate).date(1).month(intendedMonth).endOf('month');
+                  }
                 }
 
                 if (targetDate.isAfter(now, 'day')) break;
@@ -857,7 +885,7 @@ setBalanceStartDate: async (date) => {
                   return dayjs(d.date).isSame(targetDate, 'month');
                 });
 
-                const existsInPeriod = state.transactions.some(t => {
+                const existsInPeriod = transactions.some(t => {
                   if (t.recurringLinkId !== payload.id) return false;
                   if (payload.frequency === 'yearly') {
                     return dayjs(t.date).year() === targetDate.year();
@@ -888,10 +916,18 @@ setBalanceStartDate: async (date) => {
             hasNewTransactions = newTransactions.length > 0;
 
             if (!hasNewTransactions) {
+              if (transactions !== state.transactions) {
+                return {
+                  transactions,
+                  recurringTransactions: updatedRecurring,
+                  isSaving: false,
+                  isCheckingRecurring: false,
+                };
+              }
               return { isSaving: false, isCheckingRecurring: false, recurringTransactions: updatedRecurring };
             }
 
-            const allTransactions = [...state.transactions, ...newTransactions].sort((a, b) => dayjs(b.date).unix() - dayjs(a.date).unix());
+            const allTransactions = [...transactions, ...newTransactions].sort((a, b) => dayjs(b.date).unix() - dayjs(a.date).unix());
             return {
               transactions: allTransactions,
               recurringTransactions: updatedRecurring,
@@ -901,6 +937,14 @@ setBalanceStartDate: async (date) => {
           });
 
           if (hasNewTransactions) {
+            const docRef = doc(db, 'users', userId);
+            const sanitizedTransactions = useFinanceStore.getState().transactions.map(Sanitization.sanitizeTransaction);
+            const sanitizedRecurring = useFinanceStore.getState().recurringTransactions.map(Sanitization.sanitizeRecurring);
+            await updateDoc(docRef, {
+              transactions: sanitizedTransactions,
+              recurringTransactions: sanitizedRecurring,
+            });
+          } else if (hasCleanup) {
             const docRef = doc(db, 'users', userId);
             const sanitizedTransactions = useFinanceStore.getState().transactions.map(Sanitization.sanitizeTransaction);
             const sanitizedRecurring = useFinanceStore.getState().recurringTransactions.map(Sanitization.sanitizeRecurring);


### PR DESCRIPTION
## Summary

Yearly recurring transactions (e.g., Google One subscription) were generated in the wrong month because `checkRecurring()` never read `payload.monthOfYear` — it only set `dayOfMonth`, keeping the month from `startDate` or `balanceStartDate`.

## Changes

###  — `checkRecurring()`

**1. Read `monthOfYear` in target date computation** — After setting the day, adjust the month for yearly transactions using `payload.monthOfYear`. Handles day overflow in the target month (e.g., day 31 in a 30-day month).

**2. Auto-cleanup of existing wrong instances** — Detects yearly-generated transactions whose month doesn't match the template's `monthOfYear` and removes them. The generation loop then recreates them with correct dates. Cleanup is persisted to Firestore even when no new transactions are generated.

## Migration

Transparent — runs automatically on next `checkRecurring()` call (page reload or session start).

Closes #142