### PR TITLE
Fix: checkRecurring transactions not persisted to sub-collection

### DIFF
--- a/docs/YATF/wiki/bugs/recurring-transaction-monthofyear.md
+++ b/docs/YATF/wiki/bugs/recurring-transaction-monthofyear.md
@@ -65,11 +65,17 @@ if (payload.frequency === 'yearly' && payload.monthOfYear != null) {
 
 This sets the correct month after the day is applied, then handles day overflow in the new month (e.g., day 31 in a 30-day month snaps to end-of-month).
 
-**Fix 2 — Auto-cleanup of existing wrong instances** (lines 826-842):
+**Fix 2 — Auto-correct dates of existing wrong instances** (lines 826-842):
 
-Added a one-time cleanup pass at the start of `checkRecurring()` that detects yearly-generated transactions whose date month doesn't match the template's `monthOfYear` and removes them. The subsequent generation loop then recreates them with the correct dates. The cleanup is persisted to Firestore even when no new transactions are generated.
+Instead of delete-and-regenerate (which had a `lastGeneratedUpTo` gap problem), the fix corrects dates in-place: finds yearly-generated transactions whose month doesn't match the template's `monthOfYear` and rewrites their date to the correct month/day.
 
-**Migration**: The fix is transparent — it runs on the next `checkRecurring()` call (page reload or session start). Wrong instances are removed and correct ones generated automatically.
+**Fix 3 — Write to sub-collection instead of legacy `UserDoc.transactions`** (lines 940-960):
+
+After Phase 1.1 sub-collection migration, `checkRecurring()` was still writing modified/regenerated transactions to the legacy `UserDoc.transactions` field — which is no longer read. Transactions never persisted across page loads.
+
+Now uses `writeBatch` on the sub-collection via `getTransactionsCollectionRef()`, matching the pattern used by `setTransactions` and other CRUD functions.
+
+**Migration**: The fix is transparent — it runs on the next `checkRecurring()` call (page reload or session start). Wrong dates are corrected in Firestore automatically.
 
 ## Related
 

--- a/src/store/useFinanceStore.ts
+++ b/src/store/useFinanceStore.ts
@@ -824,21 +824,22 @@ setBalanceStartDate: async (date) => {
             const balanceStart = dayjs(state.balanceStartDate);
 
             let transactions = state.transactions;
-            const needsCleanup = state.recurringTransactions.some(r => r.frequency === 'yearly' && r.monthOfYear != null);
-            if (needsCleanup) {
-              const wrongIds = new Set(
-                state.transactions
-                  .filter(t => {
-                    if (!t.recurringLinkId) return false;
-                    const r = state.recurringTransactions.find(x => x.id === t.recurringLinkId);
-                    return r?.frequency === 'yearly' && r.monthOfYear != null
-                      && dayjs(t.date).month() !== r.monthOfYear - 1;
-                  })
-                  .map(t => t.id)
-              );
-              if (wrongIds.size > 0) {
-                transactions = state.transactions.filter(t => !wrongIds.has(t.id));
-                hasCleanup = true;
+            if (state.recurringTransactions.some(r => r.frequency === 'yearly' && r.monthOfYear != null)) {
+              const corrected = state.transactions.map(t => {
+                if (!t.recurringLinkId) return t;
+                const r = state.recurringTransactions.find(x => x.id === t.recurringLinkId);
+                if (r?.frequency === 'yearly' && r.monthOfYear != null) {
+                  const tDate = dayjs(t.date);
+                  if (tDate.month() !== r.monthOfYear - 1) {
+                    hasCleanup = true;
+                    const fixed = dayjs(t.date).month(r.monthOfYear - 1).date(r.dayOfMonth);
+                    return { ...t, date: fixed.format('YYYY-MM-DD') };
+                  }
+                }
+                return t;
+              });
+              if (hasCleanup) {
+                transactions = corrected;
               }
             }
 
@@ -936,22 +937,18 @@ setBalanceStartDate: async (date) => {
             };
           });
 
-          if (hasNewTransactions) {
+          if (hasNewTransactions || hasCleanup) {
+            const collRef = getTransactionsCollectionRef(userId);
+            const batch = writeBatch(db);
+            for (const txn of useFinanceStore.getState().transactions) {
+              const txnRef = doc(collRef, txn.id);
+              batch.set(txnRef, Sanitization.sanitizeTransaction(txn));
+            }
+            await batch.commit();
+
             const docRef = doc(db, 'users', userId);
-            const sanitizedTransactions = useFinanceStore.getState().transactions.map(Sanitization.sanitizeTransaction);
             const sanitizedRecurring = useFinanceStore.getState().recurringTransactions.map(Sanitization.sanitizeRecurring);
-            await updateDoc(docRef, {
-              transactions: sanitizedTransactions,
-              recurringTransactions: sanitizedRecurring,
-            });
-          } else if (hasCleanup) {
-            const docRef = doc(db, 'users', userId);
-            const sanitizedTransactions = useFinanceStore.getState().transactions.map(Sanitization.sanitizeTransaction);
-            const sanitizedRecurring = useFinanceStore.getState().recurringTransactions.map(Sanitization.sanitizeRecurring);
-            await updateDoc(docRef, {
-              transactions: sanitizedTransactions,
-              recurringTransactions: sanitizedRecurring,
-            });
+            await updateDoc(docRef, { recurringTransactions: sanitizedRecurring });
           } else {
             const docRef = doc(db, 'users', userId);
             const sanitizedRecurring = useFinanceStore.getState().recurringTransactions.map(Sanitization.sanitizeRecurring);


### PR DESCRIPTION
## Problem

After Phase 1.1 sub-collection migration, `checkRecurring()` was still writing modified/corrected transactions to the legacy `UserDoc.transactions` field (no longer read). Transactions modified by `checkRecurring()` (date corrections, new generated instances) were never persisted — they worked in-memory but disappeared on page reload.

This meant the `monthOfYear` fix from PR #143 ran correctly in memory but the corrected dates were never saved to Firestore.

## Changes

### `src/store/useFinanceStore.ts` — `checkRecurring()`

Replaced `updateDoc(docRef, { transactions: ... })` (legacy UserDoc field) with `writeBatch` to the sub-collection via `getTransactionsCollectionRef()`, matching the pattern used by `setTransactions()` and all other CRUD operations.

Also switched from delete-and-regenerate to in-place date correction for existing wrong instances — avoids a `lastGeneratedUpTo` gap issue.

## Related

- Previous fix PR: #143
- This is the remaining piece that makes the monthOfYear fix actually persist