### PR TITLE
feat: beta disclaimer banner on Dashboard (#149)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -90,7 +90,9 @@
     "totalExpenses": "Total Expenses",
     "incomeMonth": "Income (Month)",
     "expensesMonth": "Expenses (Month)",
-    "netDeltaMonth": "Net Delta (Month)"
+    "netDeltaMonth": "Net Delta (Month)",
+    "betaDisclaimer": "Welcome to the Balancr Soft Beta!",
+    "betaDisclaimerText": "This application is currently in an experimental testing phase. While all data transmissions are encrypted and isolated inside a dedicated Firestore database, please do not input real banking credentials or highly sensitive financial passwords. This platform operates purely as a self-contained tracking sandbox and has no integrations with external banking institutions."
   },
   "salary": {
     "title": "Salary",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -90,7 +90,9 @@
     "totalExpenses": "Uscite Totali",
     "incomeMonth": "Entrate (Mese)",
     "expensesMonth": "Uscite (Mese)",
-    "netDeltaMonth": "Delta Netto (Mese)"
+    "netDeltaMonth": "Delta Netto (Mese)",
+    "betaDisclaimer": "Benvenuto nella Soft Beta di Balancr!",
+    "betaDisclaimerText": "L'applicazione è attualmente in fase di test sperimentale. Sebbene le trasmissioni dati siano crittografate e protette su un database Firestore isolato, si prega di non inserire credenziali bancarie reali o dati sensibili di conti privati. Questa piattaforma funge unicamente da registro di tracciamento simulato e autonomo, e non ha alcun collegamento diretto con istituti di credito."
   },
   "salary": {
     "title": "Stipendio",

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -97,6 +97,11 @@ const DashboardPage: React.FC = () => {
         </Typography>
       </Box>
 
+      <Alert severity="warning" variant="outlined" sx={{ mb: 3, borderRadius: 2 }}>
+        <AlertTitle sx={{ fontWeight: 700 }}>{t('dashboard.betaDisclaimer')}</AlertTitle>
+        {t('dashboard.betaDisclaimerText')}
+      </Alert>
+
       {showMileageReminder && (
         <Alert
           severity="info"


### PR DESCRIPTION
## Description

Adds a beta disclaimer banner to the Dashboard as the first actionable item of Phase 2 (Soft Beta Launch) per the go-to-market plan.

## Changes

- `src/pages/DashboardPage.tsx` — added MUI `<Alert severity="warning" variant="outlined">` after page title, before mileage reminder
- `src/locales/en.json` — added `dashboard.betaDisclaimer` and `dashboard.betaDisclaimerText` keys
- `src/locales/it.json` — Italian translations for both keys

## Implementation

Matches the existing Alert pattern used for the mileage reminder (AlertTitle, severity, variant, sx).

Closes #149