### PR TITLE
fix: hardcode app title constant instead of env var

### DIFF
--- a/docs/YATF/log.md
+++ b/docs/YATF/log.md
@@ -489,6 +489,16 @@
 - Updated index.md (61 pages) and log.md
 - Source: [raw/balancr-identity-system/balancr-identity-system.md](raw/balancr-identity-system/balancr-identity-system.md)
 
+## [2026-07-18] implement | Feature | Balancr — theme migration, UI polish
+- Migrated ~160 hardcoded color refs across 45+ files to MUI theme tokens
+- Replaced `#6366f1`/`#5b6cb8` → `primary.main`, `#0f172a` → `background.default`, `#1e293b` → `background.paper`
+- Consolidated chart palettes into `theme.chart.palette` (5 components)
+- Removed empty AppBar on desktop; mobile hamburger preserved
+- Added global `cursor: pointer` via MuiButtonBase theme override
+- Enlarged sidebar logo (56px collapsed, 48px expanded)
+- Updated [[wiki/features/balancr-branding/balancr-branding]] — added theme migration + UI polish sections
+- Updated index.md and log.md
+
 ## [2026-07-18] verify | Plan | #150 — Backup/Restore verification protocol
 - Analyzed `createBackup()` (reads from Zustand store populated by sub-collection `onSnapshot`) — ✅
 - Analyzed `importAllData()` (writes to sub-collection via `batch.set()`) — ✅

--- a/docs/YATF/wiki/features/balancr-branding/balancr-branding.md
+++ b/docs/YATF/wiki/features/balancr-branding/balancr-branding.md
@@ -34,6 +34,23 @@ Complete app rebranding from "YAFT - Yet Another Finance Tracker" to **Balancr**
 - localStorage key migrated from `myfinance_language` → `balancr_language`
 - New `BalancrLogo` SVG component integrated in Sidebar and LoginPage
 
+### Theme Migration (~45 files)
+- All ~160 hardcoded color references across 45+ files migrated to MUI theme tokens
+- `#6366f1` (old indigo, 18 files) → `primary.main`
+- `#5b6cb8` (older muted indigo, 7 files) → `primary.main`
+- `#0f172a` backgrounds → `background.default` (`#0b0f19`)
+- `#1e293b`/`#161b2e` surfaces → `background.paper` (`#111827`)
+- Semantic colors → `success.main`/`error.main`/`warning.main`
+- Chart palettes in 5 components now read `theme.chart.palette`
+- Dialog backgrounds use `background.paper`
+- Global cursor pointer via `MuiButtonBase` theme override
+
+### UI Polish
+- Empty AppBar removed on desktop; mobile hamburger preserved
+- Sidebar logo enlarged (56px collapsed, 48px expanded)
+- Sidebar selected state uses `alpha(primary.main, 0.15)` from theme
+- `cursor: pointer` on all interactive elements
+
 ### Backward Compatibility
 - Old backups with `app: 'myfinance'` are still accepted during import
 - Old localStorage key `myfinance_language` is migrated to `balancr_language` on first load
@@ -43,6 +60,7 @@ Complete app rebranding from "YAFT - Yet Another Finance Tracker" to **Balancr**
 - Branch naming convention `feat/YATF-{n}` / `fix/YATF-{n}` retained for historical continuity
 - SVG logo created as reusable React component
 - Color palette applied to MUI theme
+- Changing `theme.ts` now propagates globally across the app
 
 ## Related
 - Issue: [#82](https://github.com/AlexDevsTheWeb/myfinance/issues/82)

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -29,9 +29,10 @@ import { useTranslation } from 'react-i18next';
 import { useFinanceStore } from '../../store/useFinanceStore';
 import { useLogout } from '../../hooks/useLogout';
 import { useAuthStore } from '../../store/useAuthStore';
-import { getEnvVar } from '../../utils/variables.utils';
 import { alpha, useTheme } from '@mui/material/styles';
 import BalancrLogo from '../BalancrLogo';
+
+const APP_TITLE = 'BALANCR';
 
 const drawerWidthExpanded = 240;
 const drawerWidthCollapsed = 64;
@@ -48,7 +49,6 @@ const Sidebar: React.FC<SidebarProps> = ({ onNavClick }) => {
   const logout = useLogout();
   const isMobile = useMediaQuery('(max-width: 899.95px)');
   const theme = useTheme();
-  const appTitle = getEnvVar('VITE_REACT_APP_TITLE');
   const [collapsed, setCollapsed] = useState(false);
 
   const isActive = (path: string) => location.pathname === path;
@@ -99,7 +99,7 @@ const Sidebar: React.FC<SidebarProps> = ({ onNavClick }) => {
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, px: 2, py: 2 }}>
           <BalancrLogo size={48} />
           <Typography variant="h5" sx={{ fontWeight: 800, letterSpacing: -1, color: 'common.white', whiteSpace: 'nowrap' }}>
-            {appTitle}
+            {APP_TITLE}
           </Typography>
         </Box>
       )}


### PR DESCRIPTION
## Fix

The app title was read from `VITE_REACT_APP_TITLE` env var via `getEnvVar()`, which throws when undefined. Since `.env.production` is gitignored, production builds crashed the sidebar entirely — the Balancr logo and name never appeared.

**Fix:** Replaced the env var with a `const APP_TITLE = 'BALANCR'` constant. The app title is not an environment secret, it's a build-time constant.

PR #153 (rebrand) → this fix → main