### PR TITLE
Fix: card utilization counter shows €0 — reset-day expenses excluded (#168)

### DIFF
--- a/docs/YATF/index.md
+++ b/docs/YATF/index.md
@@ -89,6 +89,7 @@ timestamp: 2026-07-26
 | [[wiki/bugs/recurring-transaction-monthofyear]] | ✅ Yearly recurring transactions ignore `monthOfYear` — **fixed** | [`#142`](https://github.com/AlexDevsTheWeb/myfinance/issues/142) |
 | [[wiki/bugs/recurring-transaction-duplicates-same-period]] | ✅ `checkRecurring` generates duplicates alongside manual transactions — **fixed** | [`#146`](https://github.com/AlexDevsTheWeb/myfinance/issues/146) |
 | [[wiki/bugs/charts-ui]] | ✅ All charts across the app had layout issues: padding, cutoff labels, pie spacing — **fixed** | [`raw/bugs/charts-ui/charts-ui.md`](raw/bugs/charts-ui/charts-ui.md) |
+| [[wiki/bugs/card-counter-zero]] | ✅ Card Utilization counter always €0 — reset-day expenses excluded by strict window bounds — **fixed** | [`raw/bugs/card-counter-zero/card-counter-zero.md`](raw/bugs/card-counter-zero/card-counter-zero.md) |
 
 ## Architecture
 

--- a/docs/YATF/log.md
+++ b/docs/YATF/log.md
@@ -600,3 +600,15 @@ description: "Chronological append-only record of all wiki operations: ingests, 
 - Created OpenSpec change `card-plafond-tracking` with proposal, design, specs, tasks
 - Updated [[wiki/features/card-plafond-tracking/card-plafond-tracking]] → status: **implemented**
 - Updated index.md (mark card-plafond as implemented) and log.md
+
+## [2026-08-03] ingest | Bug | Card Utilization counter €0 — Issue #168
+- Analyzed GitHub [Issue #168](https://github.com/AlexDevsTheWeb/myfinance/issues/168) — home page card counter stuck at €0
+- Created [[raw/bugs/card-counter-zero/card-counter-zero.md]] — root cause: strict `isAfter`/`isBefore` exclude expenses dated on the billing reset day
+- Created [[wiki/bugs/card-counter-zero]] — bug page (status: investigating)
+- Updated index.md, wiki/bugs/index.md, and [[wiki/features/card-plafond-tracking/card-plafond-tracking]] (related link)
+
+## [2026-08-03] fix | Bug | Card Utilization counter €0 — Issue #168
+- Fixed `src/components/dashboard/RecapCards.tsx` — billing window made inclusive of the reset day (`valueOf() >= periodStart` instead of strict `isAfter`)
+- Reset-day expenses now count toward the current period's spent; next period stays exclusive
+- Verified: simulation passes, `npm run build` clean, no new lint issues
+- Updated [[wiki/bugs/card-counter-zero]] → status: **fixed**; updated index.md, wiki/bugs/index.md

--- a/docs/YATF/raw/bugs/card-counter-zero/card-counter-zero.md
+++ b/docs/YATF/raw/bugs/card-counter-zero/card-counter-zero.md
@@ -1,0 +1,143 @@
+# GitHub Issue #168 — credit|debit card counter doesn't work
+
+**URL:** https://github.com/AlexDevsTheWeb/myfinance/issues/168
+**Author:** @AlexDevsTheWeb (Alessandro Torri)
+**Created:** 2026-08-03
+**Status:** OPEN
+**Labels:** bug
+**Related feature:** [165-card-plafond-tracking](../../165-card-plafond-tracking/165-card-plafond-tracking.md)
+
+---
+
+## Summary
+
+On the home page, the Card Utilization widget (the per-card "spent / plafond" counter) always shows `€0` spent for every credit/debit card, even when expenses have been tagged with a card.
+
+The reporter suspects it stopped working after renaming the saved cards ("Carta Credito" / "Carta Debito").
+
+## Original Report
+
+> in the home page the counter for credit card or debit card is not working, the value is always 0.
+> we should investigate, at the beginning it was working, maybe because I've changed the name of the credit and debit cards saved?
+
+---
+
+## Investigation
+
+### What is the "counter"?
+
+The home page (`src/pages/DashboardPage.tsx`) renders `RecapCards` (`src/components/dashboard/RecapCards.tsx`). The only card-related element is the **Card Utilization** widget, which renders one row per card showing:
+
+```
+<card name> [CREDIT|DEBIT]     €spent / €plafond
+<progress bar>                 €available
+```
+
+`spent` is the number that is stuck at `0`.
+
+### How `spent` is computed (`RecapCards.tsx`, `cardUtilization` useMemo)
+
+```ts
+const cardUtilization = React.useMemo(() => {
+    return cards.map(card => {
+        const resetDay = card.billingDay;
+        const now = dayjs();
+        let periodStart: dayjs.Dayjs;
+        let periodEnd: dayjs.Dayjs;
+
+        if (now.date() >= resetDay) {
+            periodStart = now.date(resetDay).startOf('day');
+            periodEnd = now.add(1, 'month').date(resetDay).startOf('day');
+        } else {
+            periodStart = now.subtract(1, 'month').date(resetDay).startOf('day');
+            periodEnd = now.date(resetDay).startOf('day');
+        }
+
+        const spent = transactions
+            .filter(t =>
+                t.type === 'expense' &&
+                t.cardId === card.id &&
+                dayjs(t.date).isAfter(periodStart) &&   // <-- STRICT AFTER
+                dayjs(t.date).isBefore(periodEnd)        // <-- STRICT BEFORE
+            )
+            .reduce((sum, t) => sum + t.amount, 0);
+        ...
+    });
+}, [cards, transactions]);
+```
+
+### Root cause: off-by-one boundary exclusion on the reset day
+
+The billing window is computed as `(periodStart, periodEnd)` — **exclusive of the start date** — because both `isAfter(periodStart)` and `isBefore(periodEnd)` are strict.
+
+`periodStart` is the current billing cycle's start, i.e. the card's `billingDay` of the current month (default `billingDay = 1`).
+
+Therefore **every expense dated exactly on the billing reset day is silently dropped** from the spent counter:
+
+- A transaction dated `2026-08-01` (reset day) → `isAfter(Aug 1 00:00)` is `false` → excluded.
+- A transaction dated `2026-08-01` is also excluded from the *previous* period `(Jul 1, Aug 1)` because `isBefore(Aug 1 00:00)` is `false`.
+
+So expenses on the 1st of the month are **never** counted in any period.
+
+### Why the counter looks "always 0"
+
+The card feature shipped on **2026-07-26** (commit `420cb8d`, PR #166/#167). The reporter tagged card expenses in late July and saw correct values while the window was `(Jul 1, Aug 1)`.
+
+On **Aug 1** the window rolled to `(Aug 1, Sep 1)`:
+
+1. All late-July expenses fell outside the new window (correct rollover behavior).
+2. Any new August expenses made **on the 1st** are excluded by the off-by-one bug.
+3. Result: the widget shows `€0` until a card expense is dated strictly after the 1st.
+
+The monthly rollover on the reset day is the natural "reset", but combined with the boundary bug the counter appears permanently stuck at 0.
+
+### Renaming the cards — red herring?
+
+No name-based matching exists in the codebase. Every match is by **card ID**:
+
+- `RecapCards.tsx`: `t.cardId === card.id`
+- `TransactionsPage.tsx` filter: `t.cardId === cardFilter`
+- `TransactionForm.tsx` dropdown: `<MenuItem value={card.id}>`
+
+Renaming via the **Edit** dialog (`ConfigPage.tsx` → `handleSaveCard`) preserves the card `id` (spread from `editingCard`), and `updateCard` in the store maps by `id`. So a pure rename does **not** orphan transactions.
+
+**However:** if the reporter *deleted* the old cards and *re-added* them under new names, new `crypto.randomUUID()` ids are generated, and pre-existing transactions keep pointing at the old ids → spent is 0 for the new cards. This is a data-level possibility and should be verified (check Firestore `users/{uid}.cards` ids vs `transactions/{id}.cardId`) if the boundary fix does not resolve the symptom.
+
+### Evidence
+
+Simulation with the exact production logic (`billingDay = 1`, "today" = 2026-08-03):
+
+| Transaction | Date | Expected | Code result |
+|---|---|---|---|
+| Jul 28 | outside window | — | excluded ✓ |
+| Aug 01 | inside window (reset day) | counted | **excluded ✗ (bug)** |
+| Aug 02 | inside window | counted | counted ✓ |
+
+The Aug 1 expense (reset day) is the one that should count but is dropped.
+
+---
+
+## Proposed Fix
+
+Make the billing window **inclusive of the start** and **exclusive of the end**: `[periodStart, periodEnd)`.
+
+Replace the strict `isAfter` / `isBefore` with timestamp comparisons (no dayjs plugin needed):
+
+```ts
+const spent = transactions
+    .filter(t =>
+        t.type === 'expense' &&
+        t.cardId === card.id &&
+        dayjs(t.date).valueOf() >= periodStart.valueOf() &&
+        dayjs(t.date).valueOf() < periodEnd.valueOf()
+    )
+    .reduce((sum, t) => sum + t.amount, 0);
+```
+
+This counts expenses on the billing reset day while keeping the next period's start exclusive (no double counting).
+
+## Files
+
+| File | Change |
+|------|--------|
+| `src/components/dashboard/RecapCards.tsx` | `cardUtilization`: inclusive start boundary for spent filter |

--- a/docs/YATF/wiki/bugs/card-counter-zero.md
+++ b/docs/YATF/wiki/bugs/card-counter-zero.md
@@ -1,0 +1,62 @@
+---
+type: Bug
+title: "Card utilization counter shows €0 — billing period boundary bug"
+description: "Home page Card Utilization widget always shows €0 spent because expenses dated on the billing reset day are excluded by strict isAfter/isBefore window bounds."
+resource: "https://github.com/AlexDevsTheWeb/myfinance/issues/168"
+tags: [bug, dashboard, cards, plafond]
+created: 2026-08-03
+updated: 2026-08-03
+status: fixed
+severity: major
+sources: ["raw/bugs/card-counter-zero/card-counter-zero.md"]
+related: ["wiki/features/card-plafond-tracking/card-plafond-tracking.md"]
+---
+
+# Bug: Card utilization counter shows €0
+
+Status: **fixed**
+Severity: **major**
+
+## Symptom
+
+On the home page, the **Card Utilization** widget (per-card `spent / plafond` counter) always shows `€0` spent for every credit/debit card, even when expenses have been tagged with a card.
+
+Reporter suspects it broke after renaming the saved cards.
+
+## Reproduction
+
+1. Create a card with default `billingDay = 1` (calendar month) under an account.
+2. Add an expense tagged with that card on a date **equal to the reset day** (e.g. the 1st of the month).
+3. Open the home page → Card Utilization shows `€0` for that card.
+4. A transaction on any day strictly after the reset day does count.
+
+## Root Cause Analysis
+
+In `src/components/dashboard/RecapCards.tsx` (`cardUtilization` memo), the billing window is built as `(periodStart, periodEnd)` and the spent filter uses strict `isAfter(periodStart)` **and** strict `isBefore(periodEnd)`.
+
+`periodStart` is the current cycle's `billingDay` of the current month (default 1). Any expense dated exactly on that day fails `isAfter` for the current window and also fails `isBefore` for the previous window — so **reset-day expenses are never counted in any period**.
+
+After the natural monthly rollover (Aug 1), late-July expenses fall out of the window and any new expense on the 1st is dropped by the bug → the counter appears permanently stuck at `€0`.
+
+Renaming cards via the Edit dialog preserves card `id` (all matching is by ID, not name), so a pure rename is a red herring. If cards were **deleted + re-created** (new `crypto.randomUUID()` ids), old transactions become orphaned — a data-level possibility to verify if the fix doesn't resolve the symptom.
+
+## Fix
+
+Made the billing window inclusive of the start: `[periodStart, periodEnd)` by replacing the strict `isAfter`/`isBefore` with timestamp comparisons in `src/components/dashboard/RecapCards.tsx`.
+
+```ts
+dayjs(t.date).valueOf() >= periodStart.valueOf() &&
+dayjs(t.date).valueOf() < periodEnd.valueOf()
+```
+
+This counts expenses on the billing reset day while keeping the next period's start exclusive (no double counting).
+
+### Verification
+
+- Simulation of the production logic confirms reset-day expenses now count (e.g. Aug 1 + Aug 2 → 500, previously 300 missing the Aug 1 expense).
+- `npm run build` passes (0 type errors); `npm run lint` shows no new issues in `RecapCards.tsx`.
+
+## Related
+
+- [[wiki/features/card-plafond-tracking/card-plafond-tracking]] — the feature this bug belongs to
+- Source: [raw/bugs/card-counter-zero/card-counter-zero.md](raw/bugs/card-counter-zero/card-counter-zero.md)

--- a/docs/YATF/wiki/bugs/index.md
+++ b/docs/YATF/wiki/bugs/index.md
@@ -18,3 +18,4 @@ Bug analysis pages: symptoms, root cause, reproduction steps, and fixes.
 | [[bugs/recurring-transaction-monthofyear|recurring-transaction-monthofyear]] | Yearly recurring transactions ignore monthOfYear and generate in wrong month — fixed. |
 | [[bugs/ticker-persistence|ticker-persistence]] | BrokerAccount ticker field not persisted; PAC creates transactions with wrong ticker — fixed. |
 | [[bugs/charts-ui|charts-ui]] | All charts had layout/padding issues: excess left space, cutoff labels, pie spacing — fixed. |
+| [[bugs/card-counter-zero|card-counter-zero]] | Card Utilization counter always €0 — reset-day expenses excluded by strict window bounds — fixed. |

--- a/docs/YATF/wiki/features/card-plafond-tracking/card-plafond-tracking.md
+++ b/docs/YATF/wiki/features/card-plafond-tracking/card-plafond-tracking.md
@@ -81,4 +81,5 @@ Sort controls replaced 4 separate asc/desc buttons with 2 toggle buttons (Date, 
 
 ## Related
 
+- [[wiki/bugs/card-counter-zero]] — spent counter stuck at €0 due to billing-period boundary bug
 - Source: [raw/165-card-plafond-tracking/165-card-plafond-tracking.md](raw/165-card-plafond-tracking/165-card-plafond-tracking.md)

--- a/src/components/dashboard/RecapCards.tsx
+++ b/src/components/dashboard/RecapCards.tsx
@@ -123,8 +123,8 @@ const RecapCards: React.FC<RecapCardsProps> = ({
                 .filter(t =>
                     t.type === 'expense' &&
                     t.cardId === card.id &&
-                    dayjs(t.date).isAfter(periodStart) &&
-                    dayjs(t.date).isBefore(periodEnd)
+                    dayjs(t.date).valueOf() >= periodStart.valueOf() &&
+                    dayjs(t.date).valueOf() < periodEnd.valueOf()
                 )
                 .reduce((sum, t) => sum + t.amount, 0);
 


### PR DESCRIPTION
## Summary

Closes #168 — the home page **Card Utilization** widget always showed `€0` spent for every credit/debit card.

## Root cause

In `src/components/dashboard/RecapCards.tsx`, the billing window was built as `(periodStart, periodEnd)` and the spent filter used **strict** `isAfter(periodStart)` + `isBefore(periodEnd)`. `periodStart` is the card's `billingDay` (default 1) of the current month, so any expense dated exactly on the reset day:

- fails `isAfter` for the current window, **and**
- fails `isBefore` for the previous window

→ reset-day expenses are never counted in any period. After the Aug 1 monthly rollover, late-July tagged expenses fell out of the window and any new reset-day expense was silently dropped, leaving the counter stuck at €0.

Renaming cards is a red herring — all matching is by card `id` (preserved on edit). Only delete + re-create would orphan transactions (data-level, noted in the analysis).

## Fix

Make the window inclusive of the start (`[periodStart, periodEnd)`) using timestamp comparisons:

```ts
dayjs(t.date).valueOf() >= periodStart.valueOf() &&
dayjs(t.date).valueOf() < periodEnd.valueOf()
```

No double counting: the next period's start stays exclusive.

## Verification

- Simulation of the production logic: reset-day expenses now count (Aug 1 + Aug 2 → 500, previously missing the 200).
- `npm run build` passes clean (0 type errors).
- `npm run lint` — no new issues in `RecapCards.tsx`.
- Wiki updated: raw analysis `raw/bugs/card-counter-zero/`, bug page `wiki/bugs/card-counter-zero` (status: **fixed**), indexes + log.

## Files changed

- `src/components/dashboard/RecapCards.tsx` — inclusive start boundary in `cardUtilization`
- Wiki: `docs/YATF/raw/bugs/card-counter-zero/`, `docs/YATF/wiki/bugs/card-counter-zero.md`, `docs/YATF/index.md`, `docs/YATF/wiki/bugs/index.md`, `docs/YATF/wiki/features/card-plafond-tracking/card-plafond-tracking.md`, `docs/YATF/log.md`