### PR TITLE
feat: card selection for recurring expense templates

### DIFF
--- a/docs/YATF/index.md
+++ b/docs/YATF/index.md
@@ -2,13 +2,13 @@
 type: Index
 title: "YATF Wiki — Knowledge Bundle Index"
 description: "Master catalog of all knowledge pages for the MyFinance (Balancr) project. Entry point for agent traversal."
-timestamp: 2026-07-26
+timestamp: 2026-08-03
 ---
 
 # Wiki Index
 
-*Last updated: 2026-07-26* (Responsive chart layout for Salary + Insights)
-*Total pages: 67*
+*Last updated: 2026-08-03* (Card selection for recurring expenses)
+*Total pages: 68*
 
 ---
 
@@ -42,6 +42,7 @@ timestamp: 2026-07-26
 | [[wiki/features/loading-states/loading-states]] | ✅ Loading indicators on Dashboard, Transactions, Investments during sync | [`#138`](https://github.com/AlexDevsTheWeb/myfinance/issues/138) |
 | [[wiki/features/card-plafond-tracking/card-plafond-tracking]] | ✅ Per-card monthly plafond tracking with configurable cards per account, dashboard utilization, card filter + sort toggle | [`#165`](https://github.com/AlexDevsTheWeb/myfinance/issues/165) |
 | [[wiki/features/balancr-branding/balancr-branding]] | ✅ Complete rebrand: YAFT → Balancr, Linked Hexagons logo, new color palette | [`#82`](https://github.com/AlexDevsTheWeb/myfinance/issues/82) |
+| [[wiki/features/recurring-card-selection/recurring-card-selection]] | 📋 Card selection (None/credit/debit) on recurring expense templates, propagated to generated transactions — **planned** | [`raw/recurring-card-selection/recurring-card-selection.md`](raw/recurring-card-selection/recurring-card-selection.md) |
 
 ## Plans
 

--- a/docs/YATF/log.md
+++ b/docs/YATF/log.md
@@ -612,3 +612,17 @@ description: "Chronological append-only record of all wiki operations: ingests, 
 - Reset-day expenses now count toward the current period's spent; next period stays exclusive
 - Verified: simulation passes, `npm run build` clean, no new lint issues
 - Updated [[wiki/bugs/card-counter-zero]] → status: **fixed**; updated index.md, wiki/bugs/index.md
+
+## [2026-08-03] ingest | Feature | Card Selection for Recurring Expenses
+- Created [[raw/recurring-card-selection/recurring-card-selection.md]] — design doc for card selection on recurring expense templates (future-only propagation)
+- Created [[wiki/features/recurring-card-selection/recurring-card-selection]] — feature page, status: **planned**
+- Updated [[wiki/features/card-plafond-tracking/card-plafond-tracking]] — cross-linked to recurring-card-selection
+- Updated index.md (68 pages), wiki/features/index.md, and log.md
+- Source: [raw/recurring-card-selection/recurring-card-selection.md](raw/recurring-card-selection/recurring-card-selection.md)
+
+## [2026-08-03] fix | Bug | #168 resurfaced — Card Utilization drops credit card expenses on reset day
+- Reported: debit card counter OK, credit card counter €0 despite existing expenses (credit `billingDay: 1`, expenses dated Aug 1)
+- Root cause: the #168 fix lived only on `fix/YATF-168`; **PR #169 was unmerged** so branches based on `development` still had the strict-window bug
+- Re-applied inclusive-window fix locally; verified boundary logic and build clean
+- PR #169 later **merged to `development`** (2026-08-03) — fix now permanent; this branch merged `origin/development`
+- Note: no duplicate bug docs created — canonical #168 pages already on `development` via PR #169

--- a/docs/YATF/raw/recurring-card-selection/recurring-card-selection.md
+++ b/docs/YATF/raw/recurring-card-selection/recurring-card-selection.md
@@ -1,0 +1,79 @@
+# Card Selection for Recurring Expenses
+
+**Date:** 2026-08-03
+**Status:** Design approved — pending implementation
+**Branch:** `feat/recurring-card-selection`
+**Related:** [wiki/features/card-plafond-tracking/card-plafond-tracking] (Issue #165)
+
+## Summary
+
+Extend the card selection capability introduced by Card Plafond Tracking (#165) to **recurring expenses**. Today a user can pick "None" (directly on bank account), a credit card, or a debit card for one-off expenses, but recurring expense templates (`IRecurringTransaction`) have no `cardId` field — every generated recurring expense is created without a card, so it never counts toward card utilization and is invisible in the Transactions card filter.
+
+## Problem
+
+- `IRecurringTransaction` has no `cardId` field.
+- `TransactionForm` hides the card dropdown for recurring entries (`type === 'expense' && !isRecurring`).
+- `checkRecurring()` generates expense transactions without a `cardId`.
+- `sanitizeRecurring` and the Firestore converters drop any card field.
+- Recurring subscriptions (Netflix, Google One, Spotify, gym, etc.) are exactly the kind of predictable, monthly spending that belongs on a card plafond — they are currently untrackable.
+
+## Requirements
+
+1. Add optional `cardId?: string` to `IRecurringTransaction` (optional so existing templates default to "None"; no migration needed).
+2. Show the existing card dropdown in the recurring expense dialog (value: None / account's cards).
+3. Persist `cardId` on the recurring template (Firestore converters + sanitization).
+4. `checkRecurring()` copies the template's `cardId` onto each generated expense transaction.
+5. Recurring list items in ConfigPage show the associated card name when set.
+6. Scope decision: changing a template's card affects **future generations only** — already-generated transactions are NOT backfilled.
+
+## Design
+
+### Data model
+
+```ts
+interface IRecurringTransaction {
+  // existing fields...
+  cardId?: string;  // NEW — omitted/undefined means "None" (bank account directly)
+}
+```
+
+No migration: templates written before this change simply have no `cardId` (or `null`), which is equivalent to "None".
+
+### Data flow
+
+1. **ConfigPage recurring dialog** → `TransactionForm` renders the card dropdown for `type === 'expense'` (gate no longer includes `!isRecurring`). Account change already resets the card.
+2. **Save** → `handleConfirm` includes `cardId: recurringForm.cardId || undefined` in the payload → `addRecurring`/`updateRecurring` → Firestore.
+3. **Generation** → `checkRecurring()` spreads the template `cardId` onto each generated transaction, including the dedup/`existsInPeriod` matching (unchanged).
+4. **Downstream** → generated transactions carry `cardId`, so they automatically appear in:
+   - Card Utilization widget (dashboard, `RecapCards`)
+   - Card filter in Transactions (`TransactionsPage`)
+   - Card plafond computation (SUM of expenses per card in billing period)
+   - Backup/restore (via the transaction store, already covered)
+
+### Files to touch
+
+| File | Change |
+|------|--------|
+| `src/store/types/finance.types.ts` | Add `cardId?: string` to `IRecurringTransaction` |
+| `src/components/forms/TransactionForm.tsx` | Show card dropdown for recurring expenses (remove `!isRecurring` gate) |
+| `src/pages/ConfigPage.tsx` | `recurringForm.cardId` state + init on add/edit + include in save payload + show card name in list item |
+| `src/store/useFinanceStore.ts` | `checkRecurring()` copies `payload.cardId` to generated transactions |
+| `src/store/sanitization/recurring.ts` | Sanitize `cardId` |
+| `src/lib/converters.ts` | Include `cardId` in recurring write/read mapping |
+
+### Verification
+
+- `npm run build` passes clean (typecheck + bundle).
+- Manual: create a recurring expense with a card, reload → generated transaction carries the card, appears in Card Utilization and the Transactions card filter. Existing recurring templates without a card still generate "None" transactions.
+
+## Decisions
+
+- **Future-only generation** (no backfill): the user chose this — editing a template's card must not mutate past generated transactions, keeping history consistent.
+- **Reuse existing card dropdown** rather than building a new control; behavior is identical to one-off expenses ("None" = directly on bank account).
+- **No separate GitHub issue** yet; tracked on branch `feat/recurring-card-selection`.
+
+## Alternative approaches considered (from brainstorming)
+
+- **A (chosen):** Store `cardId` on the template, propagate at generation. Simple, explicit, matches how one-off expenses work.
+- **B (rejected):** Infer card at generation time from category→card rules. Implicit magic, adds a new settings surface, no user control.
+- **C (rejected):** Per-account default card fallback. Addresses the wrong problem — the user wants per-template control, and a fallback would silently attribute spending to the wrong card.

--- a/docs/YATF/wiki/features/card-plafond-tracking/card-plafond-tracking.md
+++ b/docs/YATF/wiki/features/card-plafond-tracking/card-plafond-tracking.md
@@ -82,4 +82,5 @@ Sort controls replaced 4 separate asc/desc buttons with 2 toggle buttons (Date, 
 ## Related
 
 - [[wiki/bugs/card-counter-zero]] — spent counter stuck at €0 due to billing-period boundary bug
+- [[wiki/features/recurring-card-selection/recurring-card-selection]]
 - Source: [raw/165-card-plafond-tracking/165-card-plafond-tracking.md](raw/165-card-plafond-tracking/165-card-plafond-tracking.md)

--- a/docs/YATF/wiki/features/index.md
+++ b/docs/YATF/wiki/features/index.md
@@ -40,3 +40,4 @@ Feature pages describing all implemented, planned, and deprecated features.
 | [[features/transaction-layout-improvement/transaction-layout-improvement|transaction-layout-improvement]] | Two-column transaction layout with filter panel and chart on the left side. |
 | [[features/card-plafond-tracking/card-plafond-tracking|card-plafond-tracking]] | Track spending per card with monthly plafond, configurable per account in settings. |
 | [[features/user-configurable-rates/user-configurable-rates|user-configurable-rates]] | User-configurable inflation and tax rates in ConfigPage > Projections tab. |
+| [[features/recurring-card-selection/recurring-card-selection|recurring-card-selection]] | Card selection (None/credit/debit) on recurring expense templates, propagated to generated transactions. |

--- a/docs/YATF/wiki/features/recurring-card-selection/recurring-card-selection.md
+++ b/docs/YATF/wiki/features/recurring-card-selection/recurring-card-selection.md
@@ -1,0 +1,41 @@
+---
+type: Feature
+title: "Card Selection for Recurring Expenses"
+description: "Allow recurring expense templates to be assigned a card (None / credit / debit) so generated transactions count toward card plafond utilization."
+tags: [feature, frontend, planned]
+created: 2026-08-03
+updated: 2026-08-03
+status: planned
+sources: ["raw/recurring-card-selection/recurring-card-selection.md"]
+related: ["wiki/features/card-plafond-tracking/card-plafond-tracking.md"]
+---
+
+# Feature: Card Selection for Recurring Expenses
+
+Status: planned
+Priority: medium
+
+## Description
+
+Extends Card Plafond Tracking (#165) to recurring expenses. Recurring templates gain an optional `cardId`; the recurring expense dialog shows the same card dropdown as one-off expenses (None / account's cards), and `checkRecurring()` copies the template's card onto every generated transaction so recurring subscriptions appear in card utilization and the card filter.
+
+## Requirements
+
+- Add optional `cardId?: string` to `IRecurringTransaction` (existing templates default to "None", no migration)
+- Show the card dropdown in the recurring expense dialog
+- Persist `cardId` on the template (converters + sanitization)
+- `checkRecurring()` propagates the template's `cardId` to generated expense transactions
+- ConfigPage recurring list shows the card name when set
+- **Scope:** card changes affect future generations only — no backfill of already-generated transactions
+
+## Implementation Notes
+
+- Reuses the existing `TransactionForm` card dropdown — just remove the `!isRecurring` gate for expenses
+- Cards are pure metadata (no balance impact), consistent with #165
+- No migration needed; `cardId` is optional everywhere
+- Downstream consumers (dashboard utilization, Transactions card filter, backup) pick up generated transactions automatically
+
+## Related
+
+- [[wiki/features/card-plafond-tracking/card-plafond-tracking]]
+- Source: [raw/recurring-card-selection/recurring-card-selection.md](raw/recurring-card-selection/recurring-card-selection.md)

--- a/src/components/forms/TransactionForm.tsx
+++ b/src/components/forms/TransactionForm.tsx
@@ -315,7 +315,7 @@ const TransactionForm: React.FC<TransactionFormProps> = ({ type, formData, setFo
           {formErrors.accountId && <FormHelperText error>{formErrors.accountId}</FormHelperText>}
         </Grid>
 
-        {type === 'expense' && !isRecurring && (() => {
+        {type === 'expense' && (() => {
           const accountCards = cards.filter(c => c.accountId === formData.accountId);
           if (accountCards.length === 0) return null;
           return (

--- a/src/lib/converters.ts
+++ b/src/lib/converters.ts
@@ -123,6 +123,7 @@ export const userDocConverter: FirestoreDataConverter<UserDoc> = {
         startDate: r.startDate,
         endDate: r.endDate ?? null,
         frequency: r.frequency || 'monthly',
+        ...(r.cardId ? { cardId: r.cardId } : {}),
       })),
       carMileage: userDoc.carMileage,
       carInitialMileage: userDoc.carInitialMileage || 0,
@@ -187,6 +188,7 @@ export const userDocConverter: FirestoreDataConverter<UserDoc> = {
       endDate: r.endDate,
       frequency: r.frequency === 'yearly' || r.frequency === 'monthly' ? r.frequency : 'monthly',
       ...(r.monthOfYear ? { monthOfYear: r.monthOfYear } : {}),
+      ...(r.cardId ? { cardId: r.cardId } : {}),
     })) : [];
 
     const carMileage: ICarMileageRecord[] = Array.isArray(data.carMileage) ? data.carMileage.map((m: any) => ({

--- a/src/pages/ConfigPage.tsx
+++ b/src/pages/ConfigPage.tsx
@@ -219,7 +219,8 @@ const ConfigPage: React.FC = () => {
     type: 'expense' as 'income' | 'expense' | 'transfer',
     accountId: '',
     frequency: 'monthly' as 'monthly' | 'yearly',
-    monthOfYear: 1
+    monthOfYear: 1,
+    cardId: ''
   });
 
   const [cardDialogOpen, setCardDialogOpen] = useState(false);
@@ -332,7 +333,8 @@ const ConfigPage: React.FC = () => {
             type: rec.type,
             accountId: rec.accountId,
             frequency: rec.frequency || 'monthly',
-            monthOfYear: rec.monthOfYear || 1
+            monthOfYear: rec.monthOfYear || 1,
+            cardId: rec.cardId || ''
           });
         }
       } else {
@@ -347,7 +349,8 @@ const ConfigPage: React.FC = () => {
           type: config.financeType,
           accountId: accounts.find(a => a.isDefault)?.id || accounts[0]?.id || '',
           frequency: 'monthly',
-          monthOfYear: 1
+          monthOfYear: 1,
+          cardId: ''
         });
       }
     } else if (config?.type === 'account') {
@@ -435,7 +438,8 @@ const ConfigPage: React.FC = () => {
         type: recurringForm.type,
         accountId: recurringForm.accountId,
         frequency: recurringForm.frequency,
-        monthOfYear: recurringForm.frequency === 'yearly' ? Number(recurringForm.monthOfYear) : undefined
+        monthOfYear: recurringForm.frequency === 'yearly' ? Number(recurringForm.monthOfYear) : undefined,
+        cardId: recurringForm.cardId || undefined
       };
 
       if (dialogConfig.mode === 'add') {
@@ -890,6 +894,9 @@ const ConfigPage: React.FC = () => {
                       secondary={
                         <Typography variant="caption" sx={{ opacity: 0.6 }}>
                           {rec.category} &gt; {rec.subcategory} | Every {rec.frequency === 'yearly' ? 'year in ' + dayjs().month((rec.monthOfYear || 1) - 1).format('MMMM') : t('config.month')} on day {rec.dayOfMonth}
+                          {rec.cardId && cards.find(c => c.id === rec.cardId) && (
+                            <> | Card: {cards.find(c => c.id === rec.cardId)?.name}</>
+                          )}
                         </Typography>
                       }
                     />

--- a/src/store/sanitization/recurring.ts
+++ b/src/store/sanitization/recurring.ts
@@ -19,5 +19,6 @@ export const sanitizeRecurring = (r: IRecurringTransaction): any => {
     endDate: r.endDate || null,
     frequency: r.frequency || 'monthly',
     ...(r.frequency === 'yearly' && r.monthOfYear ? { monthOfYear: r.monthOfYear } : {}),
+    ...(r.cardId ? { cardId: r.cardId } : {}),
   };
 };

--- a/src/store/types/finance.types.ts
+++ b/src/store/types/finance.types.ts
@@ -54,6 +54,7 @@ export interface IRecurringTransaction {
   frequency?: 'monthly' | 'yearly';
   monthOfYear?: number;
   lastGeneratedUpTo?: string;
+  cardId?: string;
 }
 
 export interface IAppModules {

--- a/src/store/useFinanceStore.ts
+++ b/src/store/useFinanceStore.ts
@@ -930,6 +930,7 @@ setBalanceStartDate: async (date) => {
                     type: payload.type,
                     accountId: payload.accountId,
                     recurringLinkId: payload.id,
+                    ...(payload.cardId ? { cardId: payload.cardId } : {}),
                   });
                 }
                 current = current.add(1, payload.frequency === 'yearly' ? 'year' : 'month');


### PR DESCRIPTION
Implements card selection (None / credit / debit) on recurring expense templates, propagated to future-generated transactions.

## Changes
- Add optional `cardId` to `IRecurringTransaction` (existing templates default to None, no migration)
- Show the existing card dropdown in the recurring expense dialog (TransactionForm)
- ConfigPage: `recurringForm.cardId` state, init on add/edit, included in save payload, card name shown in recurring list
- `checkRecurring` copies the template's `cardId` onto each generated expense transaction (future generations only — no backfill)
- Persist `cardId` via `sanitizeRecurring` + Firestore converters

## Scope
- Changing a template's card affects future generations only; past generated transactions keep their value
- Income/transfer recurring templates have no card (consistent with one-off transactions)
- Generated recurring expenses now appear in Card Utilization (dashboard) and the card filter (Transactions)

## Verification
- `npm run build` clean
- Wiki: design ingested under `docs/YATF/raw/recurring-card-selection/` + feature page; OKF check passes