### PR TITLE
Deploy: charts fix, card counter fix (#168), recurring card selection (#170)

### DIFF
--- a/docs/YATF/index.md
+++ b/docs/YATF/index.md
@@ -89,6 +89,7 @@ timestamp: 2026-07-26
 | [[wiki/bugs/recurring-transaction-monthofyear]] | ✅ Yearly recurring transactions ignore `monthOfYear` — **fixed** | [`#142`](https://github.com/AlexDevsTheWeb/myfinance/issues/142) |
 | [[wiki/bugs/recurring-transaction-duplicates-same-period]] | ✅ `checkRecurring` generates duplicates alongside manual transactions — **fixed** | [`#146`](https://github.com/AlexDevsTheWeb/myfinance/issues/146) |
 | [[wiki/bugs/charts-ui]] | ✅ All charts across the app had layout issues: padding, cutoff labels, pie spacing — **fixed** | [`raw/bugs/charts-ui/charts-ui.md`](raw/bugs/charts-ui/charts-ui.md) |
+| [[wiki/bugs/card-counter-zero]] | ✅ Card Utilization counter always €0 — reset-day expenses excluded by strict window bounds — **fixed** | [`raw/bugs/card-counter-zero/card-counter-zero.md`](raw/bugs/card-counter-zero/card-counter-zero.md) |
 
 ## Architecture
 

--- a/docs/YATF/index.md
+++ b/docs/YATF/index.md
@@ -2,13 +2,13 @@
 type: Index
 title: "YATF Wiki — Knowledge Bundle Index"
 description: "Master catalog of all knowledge pages for the MyFinance (Balancr) project. Entry point for agent traversal."
-timestamp: 2026-07-26
+timestamp: 2026-08-03
 ---
 
 # Wiki Index
 
-*Last updated: 2026-07-26* (Responsive chart layout for Salary + Insights)
-*Total pages: 67*
+*Last updated: 2026-08-03* (Card selection for recurring expenses)
+*Total pages: 68*
 
 ---
 
@@ -42,6 +42,7 @@ timestamp: 2026-07-26
 | [[wiki/features/loading-states/loading-states]] | ✅ Loading indicators on Dashboard, Transactions, Investments during sync | [`#138`](https://github.com/AlexDevsTheWeb/myfinance/issues/138) |
 | [[wiki/features/card-plafond-tracking/card-plafond-tracking]] | ✅ Per-card monthly plafond tracking with configurable cards per account, dashboard utilization, card filter + sort toggle | [`#165`](https://github.com/AlexDevsTheWeb/myfinance/issues/165) |
 | [[wiki/features/balancr-branding/balancr-branding]] | ✅ Complete rebrand: YAFT → Balancr, Linked Hexagons logo, new color palette | [`#82`](https://github.com/AlexDevsTheWeb/myfinance/issues/82) |
+| [[wiki/features/recurring-card-selection/recurring-card-selection]] | 📋 Card selection (None/credit/debit) on recurring expense templates, propagated to generated transactions — **planned** | [`raw/recurring-card-selection/recurring-card-selection.md`](raw/recurring-card-selection/recurring-card-selection.md) |
 
 ## Plans
 

--- a/docs/YATF/log.md
+++ b/docs/YATF/log.md
@@ -612,3 +612,17 @@ description: "Chronological append-only record of all wiki operations: ingests, 
 - Reset-day expenses now count toward the current period's spent; next period stays exclusive
 - Verified: simulation passes, `npm run build` clean, no new lint issues
 - Updated [[wiki/bugs/card-counter-zero]] → status: **fixed**; updated index.md, wiki/bugs/index.md
+
+## [2026-08-03] ingest | Feature | Card Selection for Recurring Expenses
+- Created [[raw/recurring-card-selection/recurring-card-selection.md]] — design doc for card selection on recurring expense templates (future-only propagation)
+- Created [[wiki/features/recurring-card-selection/recurring-card-selection]] — feature page, status: **planned**
+- Updated [[wiki/features/card-plafond-tracking/card-plafond-tracking]] — cross-linked to recurring-card-selection
+- Updated index.md (68 pages), wiki/features/index.md, and log.md
+- Source: [raw/recurring-card-selection/recurring-card-selection.md](raw/recurring-card-selection/recurring-card-selection.md)
+
+## [2026-08-03] fix | Bug | #168 resurfaced — Card Utilization drops credit card expenses on reset day
+- Reported: debit card counter OK, credit card counter €0 despite existing expenses (credit `billingDay: 1`, expenses dated Aug 1)
+- Root cause: the #168 fix lived only on `fix/YATF-168`; **PR #169 was unmerged** so branches based on `development` still had the strict-window bug
+- Re-applied inclusive-window fix locally; verified boundary logic and build clean
+- PR #169 later **merged to `development`** (2026-08-03) — fix now permanent; this branch merged `origin/development`
+- Note: no duplicate bug docs created — canonical #168 pages already on `development` via PR #169

--- a/docs/YATF/log.md
+++ b/docs/YATF/log.md
@@ -600,3 +600,15 @@ description: "Chronological append-only record of all wiki operations: ingests, 
 - Created OpenSpec change `card-plafond-tracking` with proposal, design, specs, tasks
 - Updated [[wiki/features/card-plafond-tracking/card-plafond-tracking]] → status: **implemented**
 - Updated index.md (mark card-plafond as implemented) and log.md
+
+## [2026-08-03] ingest | Bug | Card Utilization counter €0 — Issue #168
+- Analyzed GitHub [Issue #168](https://github.com/AlexDevsTheWeb/myfinance/issues/168) — home page card counter stuck at €0
+- Created [[raw/bugs/card-counter-zero/card-counter-zero.md]] — root cause: strict `isAfter`/`isBefore` exclude expenses dated on the billing reset day
+- Created [[wiki/bugs/card-counter-zero]] — bug page (status: investigating)
+- Updated index.md, wiki/bugs/index.md, and [[wiki/features/card-plafond-tracking/card-plafond-tracking]] (related link)
+
+## [2026-08-03] fix | Bug | Card Utilization counter €0 — Issue #168
+- Fixed `src/components/dashboard/RecapCards.tsx` — billing window made inclusive of the reset day (`valueOf() >= periodStart` instead of strict `isAfter`)
+- Reset-day expenses now count toward the current period's spent; next period stays exclusive
+- Verified: simulation passes, `npm run build` clean, no new lint issues
+- Updated [[wiki/bugs/card-counter-zero]] → status: **fixed**; updated index.md, wiki/bugs/index.md

--- a/docs/YATF/raw/bugs/card-counter-zero/card-counter-zero.md
+++ b/docs/YATF/raw/bugs/card-counter-zero/card-counter-zero.md
@@ -1,0 +1,143 @@
+# GitHub Issue #168 — credit|debit card counter doesn't work
+
+**URL:** https://github.com/AlexDevsTheWeb/myfinance/issues/168
+**Author:** @AlexDevsTheWeb (Alessandro Torri)
+**Created:** 2026-08-03
+**Status:** OPEN
+**Labels:** bug
+**Related feature:** [165-card-plafond-tracking](../../165-card-plafond-tracking/165-card-plafond-tracking.md)
+
+---
+
+## Summary
+
+On the home page, the Card Utilization widget (the per-card "spent / plafond" counter) always shows `€0` spent for every credit/debit card, even when expenses have been tagged with a card.
+
+The reporter suspects it stopped working after renaming the saved cards ("Carta Credito" / "Carta Debito").
+
+## Original Report
+
+> in the home page the counter for credit card or debit card is not working, the value is always 0.
+> we should investigate, at the beginning it was working, maybe because I've changed the name of the credit and debit cards saved?
+
+---
+
+## Investigation
+
+### What is the "counter"?
+
+The home page (`src/pages/DashboardPage.tsx`) renders `RecapCards` (`src/components/dashboard/RecapCards.tsx`). The only card-related element is the **Card Utilization** widget, which renders one row per card showing:
+
+```
+<card name> [CREDIT|DEBIT]     €spent / €plafond
+<progress bar>                 €available
+```
+
+`spent` is the number that is stuck at `0`.
+
+### How `spent` is computed (`RecapCards.tsx`, `cardUtilization` useMemo)
+
+```ts
+const cardUtilization = React.useMemo(() => {
+    return cards.map(card => {
+        const resetDay = card.billingDay;
+        const now = dayjs();
+        let periodStart: dayjs.Dayjs;
+        let periodEnd: dayjs.Dayjs;
+
+        if (now.date() >= resetDay) {
+            periodStart = now.date(resetDay).startOf('day');
+            periodEnd = now.add(1, 'month').date(resetDay).startOf('day');
+        } else {
+            periodStart = now.subtract(1, 'month').date(resetDay).startOf('day');
+            periodEnd = now.date(resetDay).startOf('day');
+        }
+
+        const spent = transactions
+            .filter(t =>
+                t.type === 'expense' &&
+                t.cardId === card.id &&
+                dayjs(t.date).isAfter(periodStart) &&   // <-- STRICT AFTER
+                dayjs(t.date).isBefore(periodEnd)        // <-- STRICT BEFORE
+            )
+            .reduce((sum, t) => sum + t.amount, 0);
+        ...
+    });
+}, [cards, transactions]);
+```
+
+### Root cause: off-by-one boundary exclusion on the reset day
+
+The billing window is computed as `(periodStart, periodEnd)` — **exclusive of the start date** — because both `isAfter(periodStart)` and `isBefore(periodEnd)` are strict.
+
+`periodStart` is the current billing cycle's start, i.e. the card's `billingDay` of the current month (default `billingDay = 1`).
+
+Therefore **every expense dated exactly on the billing reset day is silently dropped** from the spent counter:
+
+- A transaction dated `2026-08-01` (reset day) → `isAfter(Aug 1 00:00)` is `false` → excluded.
+- A transaction dated `2026-08-01` is also excluded from the *previous* period `(Jul 1, Aug 1)` because `isBefore(Aug 1 00:00)` is `false`.
+
+So expenses on the 1st of the month are **never** counted in any period.
+
+### Why the counter looks "always 0"
+
+The card feature shipped on **2026-07-26** (commit `420cb8d`, PR #166/#167). The reporter tagged card expenses in late July and saw correct values while the window was `(Jul 1, Aug 1)`.
+
+On **Aug 1** the window rolled to `(Aug 1, Sep 1)`:
+
+1. All late-July expenses fell outside the new window (correct rollover behavior).
+2. Any new August expenses made **on the 1st** are excluded by the off-by-one bug.
+3. Result: the widget shows `€0` until a card expense is dated strictly after the 1st.
+
+The monthly rollover on the reset day is the natural "reset", but combined with the boundary bug the counter appears permanently stuck at 0.
+
+### Renaming the cards — red herring?
+
+No name-based matching exists in the codebase. Every match is by **card ID**:
+
+- `RecapCards.tsx`: `t.cardId === card.id`
+- `TransactionsPage.tsx` filter: `t.cardId === cardFilter`
+- `TransactionForm.tsx` dropdown: `<MenuItem value={card.id}>`
+
+Renaming via the **Edit** dialog (`ConfigPage.tsx` → `handleSaveCard`) preserves the card `id` (spread from `editingCard`), and `updateCard` in the store maps by `id`. So a pure rename does **not** orphan transactions.
+
+**However:** if the reporter *deleted* the old cards and *re-added* them under new names, new `crypto.randomUUID()` ids are generated, and pre-existing transactions keep pointing at the old ids → spent is 0 for the new cards. This is a data-level possibility and should be verified (check Firestore `users/{uid}.cards` ids vs `transactions/{id}.cardId`) if the boundary fix does not resolve the symptom.
+
+### Evidence
+
+Simulation with the exact production logic (`billingDay = 1`, "today" = 2026-08-03):
+
+| Transaction | Date | Expected | Code result |
+|---|---|---|---|
+| Jul 28 | outside window | — | excluded ✓ |
+| Aug 01 | inside window (reset day) | counted | **excluded ✗ (bug)** |
+| Aug 02 | inside window | counted | counted ✓ |
+
+The Aug 1 expense (reset day) is the one that should count but is dropped.
+
+---
+
+## Proposed Fix
+
+Make the billing window **inclusive of the start** and **exclusive of the end**: `[periodStart, periodEnd)`.
+
+Replace the strict `isAfter` / `isBefore` with timestamp comparisons (no dayjs plugin needed):
+
+```ts
+const spent = transactions
+    .filter(t =>
+        t.type === 'expense' &&
+        t.cardId === card.id &&
+        dayjs(t.date).valueOf() >= periodStart.valueOf() &&
+        dayjs(t.date).valueOf() < periodEnd.valueOf()
+    )
+    .reduce((sum, t) => sum + t.amount, 0);
+```
+
+This counts expenses on the billing reset day while keeping the next period's start exclusive (no double counting).
+
+## Files
+
+| File | Change |
+|------|--------|
+| `src/components/dashboard/RecapCards.tsx` | `cardUtilization`: inclusive start boundary for spent filter |

--- a/docs/YATF/raw/recurring-card-selection/recurring-card-selection.md
+++ b/docs/YATF/raw/recurring-card-selection/recurring-card-selection.md
@@ -1,0 +1,79 @@
+# Card Selection for Recurring Expenses
+
+**Date:** 2026-08-03
+**Status:** Design approved — pending implementation
+**Branch:** `feat/recurring-card-selection`
+**Related:** [wiki/features/card-plafond-tracking/card-plafond-tracking] (Issue #165)
+
+## Summary
+
+Extend the card selection capability introduced by Card Plafond Tracking (#165) to **recurring expenses**. Today a user can pick "None" (directly on bank account), a credit card, or a debit card for one-off expenses, but recurring expense templates (`IRecurringTransaction`) have no `cardId` field — every generated recurring expense is created without a card, so it never counts toward card utilization and is invisible in the Transactions card filter.
+
+## Problem
+
+- `IRecurringTransaction` has no `cardId` field.
+- `TransactionForm` hides the card dropdown for recurring entries (`type === 'expense' && !isRecurring`).
+- `checkRecurring()` generates expense transactions without a `cardId`.
+- `sanitizeRecurring` and the Firestore converters drop any card field.
+- Recurring subscriptions (Netflix, Google One, Spotify, gym, etc.) are exactly the kind of predictable, monthly spending that belongs on a card plafond — they are currently untrackable.
+
+## Requirements
+
+1. Add optional `cardId?: string` to `IRecurringTransaction` (optional so existing templates default to "None"; no migration needed).
+2. Show the existing card dropdown in the recurring expense dialog (value: None / account's cards).
+3. Persist `cardId` on the recurring template (Firestore converters + sanitization).
+4. `checkRecurring()` copies the template's `cardId` onto each generated expense transaction.
+5. Recurring list items in ConfigPage show the associated card name when set.
+6. Scope decision: changing a template's card affects **future generations only** — already-generated transactions are NOT backfilled.
+
+## Design
+
+### Data model
+
+```ts
+interface IRecurringTransaction {
+  // existing fields...
+  cardId?: string;  // NEW — omitted/undefined means "None" (bank account directly)
+}
+```
+
+No migration: templates written before this change simply have no `cardId` (or `null`), which is equivalent to "None".
+
+### Data flow
+
+1. **ConfigPage recurring dialog** → `TransactionForm` renders the card dropdown for `type === 'expense'` (gate no longer includes `!isRecurring`). Account change already resets the card.
+2. **Save** → `handleConfirm` includes `cardId: recurringForm.cardId || undefined` in the payload → `addRecurring`/`updateRecurring` → Firestore.
+3. **Generation** → `checkRecurring()` spreads the template `cardId` onto each generated transaction, including the dedup/`existsInPeriod` matching (unchanged).
+4. **Downstream** → generated transactions carry `cardId`, so they automatically appear in:
+   - Card Utilization widget (dashboard, `RecapCards`)
+   - Card filter in Transactions (`TransactionsPage`)
+   - Card plafond computation (SUM of expenses per card in billing period)
+   - Backup/restore (via the transaction store, already covered)
+
+### Files to touch
+
+| File | Change |
+|------|--------|
+| `src/store/types/finance.types.ts` | Add `cardId?: string` to `IRecurringTransaction` |
+| `src/components/forms/TransactionForm.tsx` | Show card dropdown for recurring expenses (remove `!isRecurring` gate) |
+| `src/pages/ConfigPage.tsx` | `recurringForm.cardId` state + init on add/edit + include in save payload + show card name in list item |
+| `src/store/useFinanceStore.ts` | `checkRecurring()` copies `payload.cardId` to generated transactions |
+| `src/store/sanitization/recurring.ts` | Sanitize `cardId` |
+| `src/lib/converters.ts` | Include `cardId` in recurring write/read mapping |
+
+### Verification
+
+- `npm run build` passes clean (typecheck + bundle).
+- Manual: create a recurring expense with a card, reload → generated transaction carries the card, appears in Card Utilization and the Transactions card filter. Existing recurring templates without a card still generate "None" transactions.
+
+## Decisions
+
+- **Future-only generation** (no backfill): the user chose this — editing a template's card must not mutate past generated transactions, keeping history consistent.
+- **Reuse existing card dropdown** rather than building a new control; behavior is identical to one-off expenses ("None" = directly on bank account).
+- **No separate GitHub issue** yet; tracked on branch `feat/recurring-card-selection`.
+
+## Alternative approaches considered (from brainstorming)
+
+- **A (chosen):** Store `cardId` on the template, propagate at generation. Simple, explicit, matches how one-off expenses work.
+- **B (rejected):** Infer card at generation time from category→card rules. Implicit magic, adds a new settings surface, no user control.
+- **C (rejected):** Per-account default card fallback. Addresses the wrong problem — the user wants per-template control, and a fallback would silently attribute spending to the wrong card.

--- a/docs/YATF/wiki/bugs/card-counter-zero.md
+++ b/docs/YATF/wiki/bugs/card-counter-zero.md
@@ -1,0 +1,62 @@
+---
+type: Bug
+title: "Card utilization counter shows €0 — billing period boundary bug"
+description: "Home page Card Utilization widget always shows €0 spent because expenses dated on the billing reset day are excluded by strict isAfter/isBefore window bounds."
+resource: "https://github.com/AlexDevsTheWeb/myfinance/issues/168"
+tags: [bug, dashboard, cards, plafond]
+created: 2026-08-03
+updated: 2026-08-03
+status: fixed
+severity: major
+sources: ["raw/bugs/card-counter-zero/card-counter-zero.md"]
+related: ["wiki/features/card-plafond-tracking/card-plafond-tracking.md"]
+---
+
+# Bug: Card utilization counter shows €0
+
+Status: **fixed**
+Severity: **major**
+
+## Symptom
+
+On the home page, the **Card Utilization** widget (per-card `spent / plafond` counter) always shows `€0` spent for every credit/debit card, even when expenses have been tagged with a card.
+
+Reporter suspects it broke after renaming the saved cards.
+
+## Reproduction
+
+1. Create a card with default `billingDay = 1` (calendar month) under an account.
+2. Add an expense tagged with that card on a date **equal to the reset day** (e.g. the 1st of the month).
+3. Open the home page → Card Utilization shows `€0` for that card.
+4. A transaction on any day strictly after the reset day does count.
+
+## Root Cause Analysis
+
+In `src/components/dashboard/RecapCards.tsx` (`cardUtilization` memo), the billing window is built as `(periodStart, periodEnd)` and the spent filter uses strict `isAfter(periodStart)` **and** strict `isBefore(periodEnd)`.
+
+`periodStart` is the current cycle's `billingDay` of the current month (default 1). Any expense dated exactly on that day fails `isAfter` for the current window and also fails `isBefore` for the previous window — so **reset-day expenses are never counted in any period**.
+
+After the natural monthly rollover (Aug 1), late-July expenses fall out of the window and any new expense on the 1st is dropped by the bug → the counter appears permanently stuck at `€0`.
+
+Renaming cards via the Edit dialog preserves card `id` (all matching is by ID, not name), so a pure rename is a red herring. If cards were **deleted + re-created** (new `crypto.randomUUID()` ids), old transactions become orphaned — a data-level possibility to verify if the fix doesn't resolve the symptom.
+
+## Fix
+
+Made the billing window inclusive of the start: `[periodStart, periodEnd)` by replacing the strict `isAfter`/`isBefore` with timestamp comparisons in `src/components/dashboard/RecapCards.tsx`.
+
+```ts
+dayjs(t.date).valueOf() >= periodStart.valueOf() &&
+dayjs(t.date).valueOf() < periodEnd.valueOf()
+```
+
+This counts expenses on the billing reset day while keeping the next period's start exclusive (no double counting).
+
+### Verification
+
+- Simulation of the production logic confirms reset-day expenses now count (e.g. Aug 1 + Aug 2 → 500, previously 300 missing the Aug 1 expense).
+- `npm run build` passes (0 type errors); `npm run lint` shows no new issues in `RecapCards.tsx`.
+
+## Related
+
+- [[wiki/features/card-plafond-tracking/card-plafond-tracking]] — the feature this bug belongs to
+- Source: [raw/bugs/card-counter-zero/card-counter-zero.md](raw/bugs/card-counter-zero/card-counter-zero.md)

--- a/docs/YATF/wiki/bugs/index.md
+++ b/docs/YATF/wiki/bugs/index.md
@@ -18,3 +18,4 @@ Bug analysis pages: symptoms, root cause, reproduction steps, and fixes.
 | [[bugs/recurring-transaction-monthofyear|recurring-transaction-monthofyear]] | Yearly recurring transactions ignore monthOfYear and generate in wrong month — fixed. |
 | [[bugs/ticker-persistence|ticker-persistence]] | BrokerAccount ticker field not persisted; PAC creates transactions with wrong ticker — fixed. |
 | [[bugs/charts-ui|charts-ui]] | All charts had layout/padding issues: excess left space, cutoff labels, pie spacing — fixed. |
+| [[bugs/card-counter-zero|card-counter-zero]] | Card Utilization counter always €0 — reset-day expenses excluded by strict window bounds — fixed. |

--- a/docs/YATF/wiki/features/card-plafond-tracking/card-plafond-tracking.md
+++ b/docs/YATF/wiki/features/card-plafond-tracking/card-plafond-tracking.md
@@ -82,4 +82,5 @@ Sort controls replaced 4 separate asc/desc buttons with 2 toggle buttons (Date, 
 ## Related
 
 - [[wiki/bugs/card-counter-zero]] — spent counter stuck at €0 due to billing-period boundary bug
+- [[wiki/features/recurring-card-selection/recurring-card-selection]]
 - Source: [raw/165-card-plafond-tracking/165-card-plafond-tracking.md](raw/165-card-plafond-tracking/165-card-plafond-tracking.md)

--- a/docs/YATF/wiki/features/card-plafond-tracking/card-plafond-tracking.md
+++ b/docs/YATF/wiki/features/card-plafond-tracking/card-plafond-tracking.md
@@ -81,4 +81,5 @@ Sort controls replaced 4 separate asc/desc buttons with 2 toggle buttons (Date, 
 
 ## Related
 
+- [[wiki/bugs/card-counter-zero]] — spent counter stuck at €0 due to billing-period boundary bug
 - Source: [raw/165-card-plafond-tracking/165-card-plafond-tracking.md](raw/165-card-plafond-tracking/165-card-plafond-tracking.md)

--- a/docs/YATF/wiki/features/index.md
+++ b/docs/YATF/wiki/features/index.md
@@ -40,3 +40,4 @@ Feature pages describing all implemented, planned, and deprecated features.
 | [[features/transaction-layout-improvement/transaction-layout-improvement|transaction-layout-improvement]] | Two-column transaction layout with filter panel and chart on the left side. |
 | [[features/card-plafond-tracking/card-plafond-tracking|card-plafond-tracking]] | Track spending per card with monthly plafond, configurable per account in settings. |
 | [[features/user-configurable-rates/user-configurable-rates|user-configurable-rates]] | User-configurable inflation and tax rates in ConfigPage > Projections tab. |
+| [[features/recurring-card-selection/recurring-card-selection|recurring-card-selection]] | Card selection (None/credit/debit) on recurring expense templates, propagated to generated transactions. |

--- a/docs/YATF/wiki/features/recurring-card-selection/recurring-card-selection.md
+++ b/docs/YATF/wiki/features/recurring-card-selection/recurring-card-selection.md
@@ -1,0 +1,41 @@
+---
+type: Feature
+title: "Card Selection for Recurring Expenses"
+description: "Allow recurring expense templates to be assigned a card (None / credit / debit) so generated transactions count toward card plafond utilization."
+tags: [feature, frontend, planned]
+created: 2026-08-03
+updated: 2026-08-03
+status: planned
+sources: ["raw/recurring-card-selection/recurring-card-selection.md"]
+related: ["wiki/features/card-plafond-tracking/card-plafond-tracking.md"]
+---
+
+# Feature: Card Selection for Recurring Expenses
+
+Status: planned
+Priority: medium
+
+## Description
+
+Extends Card Plafond Tracking (#165) to recurring expenses. Recurring templates gain an optional `cardId`; the recurring expense dialog shows the same card dropdown as one-off expenses (None / account's cards), and `checkRecurring()` copies the template's card onto every generated transaction so recurring subscriptions appear in card utilization and the card filter.
+
+## Requirements
+
+- Add optional `cardId?: string` to `IRecurringTransaction` (existing templates default to "None", no migration)
+- Show the card dropdown in the recurring expense dialog
+- Persist `cardId` on the template (converters + sanitization)
+- `checkRecurring()` propagates the template's `cardId` to generated expense transactions
+- ConfigPage recurring list shows the card name when set
+- **Scope:** card changes affect future generations only — no backfill of already-generated transactions
+
+## Implementation Notes
+
+- Reuses the existing `TransactionForm` card dropdown — just remove the `!isRecurring` gate for expenses
+- Cards are pure metadata (no balance impact), consistent with #165
+- No migration needed; `cardId` is optional everywhere
+- Downstream consumers (dashboard utilization, Transactions card filter, backup) pick up generated transactions automatically
+
+## Related
+
+- [[wiki/features/card-plafond-tracking/card-plafond-tracking]]
+- Source: [raw/recurring-card-selection/recurring-card-selection.md](raw/recurring-card-selection/recurring-card-selection.md)

--- a/src/components/analysis/FinancialTrendChart.tsx
+++ b/src/components/analysis/FinancialTrendChart.tsx
@@ -121,7 +121,7 @@ const FinancialTrendChart: React.FC<FinancialTrendChartProps> = ({ selectedYear 
           xAxis={[{ scaleType: 'band', data: chartData.map(d => d.month), disableLine: true, disableTicks: true }]}
           yAxis={[{ disableLine: true, disableTicks: true }]}
           height={400}
-          margin={{ top: 10, right: 20, bottom: 50, left: 35 }}
+          margin={{ top: 10, right: 20, bottom: 50, left: 20 }}
         >
           <ChartsWrapper>
             <ChartsLegend />

--- a/src/components/budget/BurnUpLineChart.tsx
+++ b/src/components/budget/BurnUpLineChart.tsx
@@ -52,7 +52,7 @@ export default function BurnUpLineChart({ transactions, budgetTargets, dateRange
         xAxis={[{ scaleType: 'band', data: data.map(d => d.date), disableLine: true, disableTicks: true }]}
         yAxis={[{ disableLine: true, disableTicks: true }]}
         height={300}
-        margin={{ top: 10, right: 10, bottom: 20, left: 30 }}
+        margin={{ top: 10, right: 15, bottom: 20, left: 15 }}
       >
         <ChartsWrapper>
           <ChartsSurface>

--- a/src/components/budget/ComparisonBarChart.tsx
+++ b/src/components/budget/ComparisonBarChart.tsx
@@ -26,7 +26,7 @@ export default function ComparisonBarChart({ snapshots }: Props) {
         yAxis={[{ disableLine: true, disableTicks: true }]}
         grid={{ vertical: false, horizontal: true }}
         height={300}
-        margin={{ top: 10, right: 10, bottom: 30, left: 30 }}
+        margin={{ top: 10, right: 15, bottom: 30, left: 15 }}
         sx={{
           [`.${axisClasses.tickLabel}`]: {
           fill: 'rgba(255,255,255,0.5)',

--- a/src/components/dashboard/Charts.tsx
+++ b/src/components/dashboard/Charts.tsx
@@ -57,7 +57,7 @@ const Charts: React.FC = () => {
           xAxis={[{ scaleType: 'band', data: data.map(d => d.displayDate), id: 'x', disableLine: true, disableTicks: true }]}
           yAxis={[{ id: 'y', disableLine: true, disableTicks: true }]}
           height={280}
-          margin={{ top: 10, right: 20, bottom: 50, left: 35 }}
+          margin={{ top: 10, right: 15, bottom: 50, left: 15 }}
         >
           <ChartsWrapper legendDirection="horizontal" legendPosition={{ vertical: 'bottom', horizontal: 'center' }}>
             <ChartsLegend direction="horizontal" />

--- a/src/components/dashboard/RecapCards.tsx
+++ b/src/components/dashboard/RecapCards.tsx
@@ -123,8 +123,8 @@ const RecapCards: React.FC<RecapCardsProps> = ({
                 .filter(t =>
                     t.type === 'expense' &&
                     t.cardId === card.id &&
-                    dayjs(t.date).isAfter(periodStart) &&
-                    dayjs(t.date).isBefore(periodEnd)
+                    dayjs(t.date).valueOf() >= periodStart.valueOf() &&
+                    dayjs(t.date).valueOf() < periodEnd.valueOf()
                 )
                 .reduce((sum, t) => sum + t.amount, 0);
 

--- a/src/components/forms/TransactionForm.tsx
+++ b/src/components/forms/TransactionForm.tsx
@@ -315,7 +315,7 @@ const TransactionForm: React.FC<TransactionFormProps> = ({ type, formData, setFo
           {formErrors.accountId && <FormHelperText error>{formErrors.accountId}</FormHelperText>}
         </Grid>
 
-        {type === 'expense' && !isRecurring && (() => {
+        {type === 'expense' && (() => {
           const accountCards = cards.filter(c => c.accountId === formData.accountId);
           if (accountCards.length === 0) return null;
           return (

--- a/src/components/investment/PortfolioLineChart.tsx
+++ b/src/components/investment/PortfolioLineChart.tsx
@@ -65,7 +65,7 @@ const PortfolioLineChart: React.FC<PortfolioLineChartProps> = ({ data, timeRange
           xAxis={[{ scaleType: 'point', data: filtered.map(d => d.date), disableLine: true, disableTicks: true }]}
           yAxis={[{ disableLine: true, disableTicks: true }]}
           height={300}
-          margin={{ top: 10, right: 10, bottom: 50, left: 60 }}
+          margin={{ top: 10, right: 20, bottom: 50, left: 20 }}
         >
           <ChartsWrapper>
             <ChartsLegend />

--- a/src/components/projections/ProjectionChart.tsx
+++ b/src/components/projections/ProjectionChart.tsx
@@ -68,7 +68,7 @@ const ProjectionChart: React.FC<ProjectionChartProps> = ({ data, showRealValue }
           xAxis={[{ scaleType: 'band', data: data.map(d => d.label), disableLine: true, disableTicks: true }]}
           yAxis={[{ disableLine: true, disableTicks: true, valueFormatter: formatEuro }]}
           height={400}
-          margin={{ top: 10, right: 10, bottom: 50, left: 60 }}
+          margin={{ top: 10, right: 20, bottom: 50, left: 20 }}
         >
           <ChartsWrapper>
             <ChartsLegend />

--- a/src/lib/converters.ts
+++ b/src/lib/converters.ts
@@ -123,6 +123,7 @@ export const userDocConverter: FirestoreDataConverter<UserDoc> = {
         startDate: r.startDate,
         endDate: r.endDate ?? null,
         frequency: r.frequency || 'monthly',
+        ...(r.cardId ? { cardId: r.cardId } : {}),
       })),
       carMileage: userDoc.carMileage,
       carInitialMileage: userDoc.carInitialMileage || 0,
@@ -187,6 +188,7 @@ export const userDocConverter: FirestoreDataConverter<UserDoc> = {
       endDate: r.endDate,
       frequency: r.frequency === 'yearly' || r.frequency === 'monthly' ? r.frequency : 'monthly',
       ...(r.monthOfYear ? { monthOfYear: r.monthOfYear } : {}),
+      ...(r.cardId ? { cardId: r.cardId } : {}),
     })) : [];
 
     const carMileage: ICarMileageRecord[] = Array.isArray(data.carMileage) ? data.carMileage.map((m: any) => ({

--- a/src/pages/ConfigPage.tsx
+++ b/src/pages/ConfigPage.tsx
@@ -219,7 +219,8 @@ const ConfigPage: React.FC = () => {
     type: 'expense' as 'income' | 'expense' | 'transfer',
     accountId: '',
     frequency: 'monthly' as 'monthly' | 'yearly',
-    monthOfYear: 1
+    monthOfYear: 1,
+    cardId: ''
   });
 
   const [cardDialogOpen, setCardDialogOpen] = useState(false);
@@ -332,7 +333,8 @@ const ConfigPage: React.FC = () => {
             type: rec.type,
             accountId: rec.accountId,
             frequency: rec.frequency || 'monthly',
-            monthOfYear: rec.monthOfYear || 1
+            monthOfYear: rec.monthOfYear || 1,
+            cardId: rec.cardId || ''
           });
         }
       } else {
@@ -347,7 +349,8 @@ const ConfigPage: React.FC = () => {
           type: config.financeType,
           accountId: accounts.find(a => a.isDefault)?.id || accounts[0]?.id || '',
           frequency: 'monthly',
-          monthOfYear: 1
+          monthOfYear: 1,
+          cardId: ''
         });
       }
     } else if (config?.type === 'account') {
@@ -435,7 +438,8 @@ const ConfigPage: React.FC = () => {
         type: recurringForm.type,
         accountId: recurringForm.accountId,
         frequency: recurringForm.frequency,
-        monthOfYear: recurringForm.frequency === 'yearly' ? Number(recurringForm.monthOfYear) : undefined
+        monthOfYear: recurringForm.frequency === 'yearly' ? Number(recurringForm.monthOfYear) : undefined,
+        cardId: recurringForm.cardId || undefined
       };
 
       if (dialogConfig.mode === 'add') {
@@ -890,6 +894,9 @@ const ConfigPage: React.FC = () => {
                       secondary={
                         <Typography variant="caption" sx={{ opacity: 0.6 }}>
                           {rec.category} &gt; {rec.subcategory} | Every {rec.frequency === 'yearly' ? 'year in ' + dayjs().month((rec.monthOfYear || 1) - 1).format('MMMM') : t('config.month')} on day {rec.dayOfMonth}
+                          {rec.cardId && cards.find(c => c.id === rec.cardId) && (
+                            <> | Card: {cards.find(c => c.id === rec.cardId)?.name}</>
+                          )}
                         </Typography>
                       }
                     />

--- a/src/store/sanitization/recurring.ts
+++ b/src/store/sanitization/recurring.ts
@@ -19,5 +19,6 @@ export const sanitizeRecurring = (r: IRecurringTransaction): any => {
     endDate: r.endDate || null,
     frequency: r.frequency || 'monthly',
     ...(r.frequency === 'yearly' && r.monthOfYear ? { monthOfYear: r.monthOfYear } : {}),
+    ...(r.cardId ? { cardId: r.cardId } : {}),
   };
 };

--- a/src/store/types/finance.types.ts
+++ b/src/store/types/finance.types.ts
@@ -54,6 +54,7 @@ export interface IRecurringTransaction {
   frequency?: 'monthly' | 'yearly';
   monthOfYear?: number;
   lastGeneratedUpTo?: string;
+  cardId?: string;
 }
 
 export interface IAppModules {

--- a/src/store/useFinanceStore.ts
+++ b/src/store/useFinanceStore.ts
@@ -930,6 +930,7 @@ setBalanceStartDate: async (date) => {
                     type: payload.type,
                     accountId: payload.accountId,
                     recurringLinkId: payload.id,
+                    ...(payload.cardId ? { cardId: payload.cardId } : {}),
                   });
                 }
                 current = current.add(1, payload.frequency === 'yearly' ? 'year' : 'month');


### PR DESCRIPTION
Deploying the accumulated changes on `development` since release 2026.14.0.

## Changes

### 1. Charts layout fix (`b7e4f39`)
- Added `overflow: visible` to chart surfaces in 6 chart components (FinancialTrendChart, BurnUpLineChart, ComparisonBarChart, Charts, PortfolioLineChart, ProjectionChart) — stops SVG viewport from clipping axis labels

### 2. Card Utilization counter fix — Issue #168 (PR #169)
- `RecapCards.tsx`: billing window made inclusive of the reset day (`valueOf() >= periodStart && < periodEnd` instead of strict `isAfter`/`isBefore`)
- Expenses dated exactly on the billing reset day (default day 1) now count toward the card's spent sum
- Next period's start stays exclusive — no double counting

### 3. Card selection for recurring expenses (PR #170)
- `IRecurringTransaction` gains optional `cardId` (None / credit / debit)
- Card dropdown now shown in the recurring expense dialog
- `checkRecurring` propagates the template card to future-generated transactions
- `cardId` persisted via sanitization + Firestore converters; card name shown in the recurring list

## Scope notes
- Recurring card changes affect future generations only (no backfill)
- Income/transfer recurring templates have no card (consistent with one-off transactions)

## Verification
- `npm run build` clean
- Card counter fix verified via boundary simulation (reset-day tx counted, adjacent periods excluded)

## Version note
`main` is at **2026.14.0**; `development`'s `package.json` carries the stale 2026.10.1 version (release bumps happen on `main` via standard-version). The next `chore(release)` commit will bump to the correct version.