### PR TITLE
fix: show localized error feedback on login/auth failures (#157)

### DIFF
--- a/docs/YATF/index.md
+++ b/docs/YATF/index.md
@@ -7,8 +7,8 @@ timestamp: 2026-08-03
 
 # Wiki Index
 
-*Last updated: 2026-08-03* (ETF pricing / Total Return bug)
-*Total pages: 70*
+*Last updated: 2026-08-06* (Silent login errors)
+*Total pages: 71*
 
 ---
 
@@ -93,6 +93,7 @@ timestamp: 2026-08-03
 | [[wiki/bugs/card-counter-zero]] | ✅ Card Utilization counter always €0 — reset-day expenses excluded by strict window bounds — **fixed** | [`raw/bugs/card-counter-zero/card-counter-zero.md`](raw/bugs/card-counter-zero/card-counter-zero.md) |
 | [[wiki/bugs/broker-transaction-filter]] | ✅ Broker filter shows 0 invested / no holdings — manual ETF transactions never persisted `brokerId` — **fixed** | [`raw/bugs/broker-transaction-filter/broker-transaction-filter.md`](raw/bugs/broker-transaction-filter/broker-transaction-filter.md) |
 | [[wiki/bugs/etf-pricing-total-return]] | ✅ Total Return stuck at €0 — price provider dead (yfin.dev); switched to Yahoo with Xetra-first resolution + SWDA→EUNL consolidation — **fixed** | [`raw/bugs/etf-pricing-total-return/etf-pricing-total-return.md`](raw/bugs/etf-pricing-total-return/etf-pricing-total-return.md) |
+| [[wiki/bugs/silent-login-errors]] | ✅ Auth failures (popup blocked, wrong password, network) silently swallowed — now localized AlertSnackbar feedback — **fixed** | [`#157`](https://github.com/AlexDevsTheWeb/myfinance/issues/157) |
 
 ## Architecture
 

--- a/docs/YATF/log.md
+++ b/docs/YATF/log.md
@@ -659,3 +659,16 @@ description: "Chronological append-only record of all wiki operations: ingests, 
 - `src/lib/converters.ts`: legacy brokerConfig ticker fallback → `EUNL`
 - Placeholders/examples updated to `EUNL.DE` (locales it/en, validation msg, BrokerSettingsModal, EtfTransactionForm, DividendDialog)
 - Verified live: `EUNL`→`EUNL.DE` 126.045 € (== TR app), `SWDA`→`SWDA.MI` 126.03 €, `VWCE`→`VWCE.DE` 165 €; `npm run build` clean, no new lint issues
+
+## [2026-08-06] ingest | Bug | Silent login errors — no user-facing feedback on auth failure
+- User report (#157): auth failures (Google popup blocked, wrong email/password, network errors) were caught and console.logged only — user sees nothing.
+- Root cause: `LoginPage.tsx` catch blocks in both `handleSubmit` (:28-31) and `handleLogin` (:41-43) swallow errors; commented-out `alert()` marks it as known-temporary. No Snackbar/Alert/error state existed on the page while the app already ships `AlertSnackbar` (used by ConfigPage). No i18n for auth messages.
+- Created [[raw/bugs/silent-login-errors/silent-login-errors.md]] — full analysis
+- Created [[wiki/bugs/silent-login-errors]] — bug page (status: fixed)
+- Updated index.md (71 pages), wiki/bugs/index.md
+- Cross-links: new-user-auth-flow, error-boundary
+
+## [2026-08-06] fix | Bug | Localized auth error feedback on login (#157)
+- Added `auth` i18n section to `src/locales/en.json` + `it.json` mapping Firebase error codes → user-friendly messages (popup-blocked, wrong-password, user-not-found, invalid-credential, invalid-email, email-already-in-use, weak-password, network-request-failed, too-many-requests, user-disabled, operation-not-allowed, popup-closed-by-user, cancelled-popup-request, generic fallback)
+- `LoginPage.tsx`: added `getAuthErrorMessage(error)` mapper + `alertState`/`showAlert()` + `<AlertSnackbar/>` wired into both catch blocks; all messages localized via `useTranslation()`
+- Verified: `npm run build` clean; `npm run lint` no new issues

--- a/docs/YATF/raw/bugs/silent-login-errors/silent-login-errors.md
+++ b/docs/YATF/raw/bugs/silent-login-errors/silent-login-errors.md
@@ -1,0 +1,91 @@
+# Bug Analysis — Silent login errors, no user-facing feedback on auth failure
+
+**Status:** FIXED (analyzed and resolved on 2026-08-06)
+**Severity:** medium
+**Related issue:** [#157](https://github.com/AlexDevsTheWeb/myfinance/issues/157)
+**Related feature:** [new-user-auth-flow](../../new-user-auth-flow/new-user-auth-flow.md)
+
+---
+
+## Summary
+
+Authentication failures on the login page produced **zero user feedback**. Both Google sign-in and email/password auth errors were caught and logged to the console only — the user saw nothing. A popup blocker silently prevented Google sign-in, wrong email/password was invisible, and network errors were uncommunicated.
+
+## Reproduction
+
+1. Open the app → Login page.
+2. **Google:** block popups in the browser, then click "Sign in with Google" → nothing visibly happens (only `console.error`).
+3. **Email/password:** enter a wrong password → the form silently resets, no error shown.
+4. **Network:** go offline, attempt login → no error, no retry hint.
+
+## Root Cause Analysis
+
+### Errors swallowed in `handleSubmit`
+
+`src/pages/LoginPage.tsx:28-31` — the `catch` block for both `signInWithEmailAndPassword` and `createUserWithEmailAndPassword` only logged the error code:
+
+```ts
+} catch (error: any) {
+  console.error("Errore:", error.code);
+  // Esempio: alert("Errore: " + error.message);
+}
+```
+
+The commented-out `alert()` (line 30) confirms this was known to be temporary and never revisited.
+
+### Errors swallowed in `handleLogin` (Google popup)
+
+`src/pages/LoginPage.tsx:41-43` — same pattern for `signInWithPopup`:
+
+```ts
+} catch (error) {
+  console.error('Error logging in:', error);
+}
+```
+
+This is the worst case: `auth/popup-blocked` is one of the most common auth failures (ad-blockers / strict browser privacy settings), yet the user clicks, sees nothing, and assumes the app is broken.
+
+### No error-display infrastructure in LoginPage
+
+The page had no Snackbar, no Alert, no error state. Meanwhile the app already ships `AlertSnackbar` (`src/components/shared/AlertSnackbar.tsx`) and ConfigPage uses a clean `alertState` + `showAlert()` + `<AlertSnackbar/>` pattern — the fix should reuse that, not invent a new mechanism.
+
+### No i18n for auth messages
+
+The rest of the app is fully localized via `react-i18next` (`en.json` / `it.json`), but the login page had hardcoded English/Italian strings and no `t()` usage for errors. Error messages must be localized to match the app convention.
+
+## Proposed Fix / Resolution
+
+1. **Add an `auth` i18n section** to `src/locales/en.json` and `src/locales/it.json` with user-friendly messages for the Firebase auth error codes:
+   - `auth/popup-blocked` — tell the user to allow popups for this site
+   - `auth/wrong-password` — wrong password
+   - `auth/user-not-found` — no account with that email
+   - `auth/invalid-credential` — (Firebase v12 may use this instead of `wrong-password`/`user-not-found`)
+   - `auth/invalid-email` — malformed email
+   - `auth/email-already-in-use` — registration with an existing email
+   - `auth/weak-password` — password too weak at registration
+   - `auth/network-request-failed` — network error
+   - `auth/too-many-requests` — rate limited, try later
+   - `auth/user-disabled` — account disabled
+   - `auth/operation-not-allowed` — auth method disabled
+   - `auth/popup-closed-by-user` / `auth/cancelled-popup-request` — user closed the popup (informational)
+   - fallback — generic "something went wrong" message
+2. **Create a `getAuthErrorMessage(error)` helper** in `LoginPage.tsx` that maps `error.code` → localized message.
+3. **Add `alertState` + `showAlert()` + `<AlertSnackbar/>`** to `LoginPage.tsx`, wired into both catch blocks.
+4. Use `useTranslation()` for all messages.
+
+## Files Modified
+
+- `src/pages/LoginPage.tsx` — error handling, AlertSnackbar, `getAuthErrorMessage`
+- `src/locales/en.json` — `auth` section
+- `src/locales/it.json` — `auth` section
+
+## Verification
+
+- `npm run build` clean; `npm run lint` no new issues.
+- Manual: wrong password → red Snackbar "Invalid email or password."; popup blocked → "Please allow popups for this site to sign in with Google."; email already in use at registration → localized message.
+- Wiki: raw analysis + `wiki/bugs/silent-login-errors` bug page created, indexes and log updated.
+
+## Related
+
+- [new-user-auth-flow](../../new-user-auth-flow/new-user-auth-flow.md) — the earlier Google auth flow analysis (data isolation, concerns)
+- `src/components/shared/AlertSnackbar.tsx` — the app-wide Snackbar used for the fix

--- a/docs/YATF/wiki/bugs/index.md
+++ b/docs/YATF/wiki/bugs/index.md
@@ -21,3 +21,4 @@ Bug analysis pages: symptoms, root cause, reproduction steps, and fixes.
 | [[bugs/card-counter-zero|card-counter-zero]] | Card Utilization counter always €0 — reset-day expenses excluded by strict window bounds — fixed. |
 | [[bugs/broker-transaction-filter|broker-transaction-filter]] | Broker filter shows 0 invested / no holdings because manual ETF transactions never persisted a brokerId — fixed. |
 | [[bugs/etf-pricing-total-return|etf-pricing-total-return]] | Total Return stuck at €0 — price provider dead (api.yfin.dev); switched to Yahoo Finance with Xetra-first venue resolution and SWDA→EUNL consolidation — fixed. |
+| [[bugs/silent-login-errors|silent-login-errors]] | Login auth failures (popup blocked, wrong password, network) silently console.logged — no user feedback. Fixed with localized AlertSnackbar messages (#157) — fixed. |

--- a/docs/YATF/wiki/bugs/silent-login-errors.md
+++ b/docs/YATF/wiki/bugs/silent-login-errors.md
@@ -1,0 +1,55 @@
+---
+type: Bug
+title: "Silent login errors — no user-facing feedback on auth failure"
+description: "Authentication failures (Google popup blocked, wrong password, network errors) were caught and console.logged only — the user saw nothing. Fixed by showing localized error messages via the app's AlertSnackbar."
+resource: "https://github.com/AlexDevsTheWeb/myfinance/issues/157"
+tags: [bug, auth, login, firebase, ux]
+created: 2026-08-06
+updated: 2026-08-06
+status: fixed
+severity: major
+sources: ["raw/bugs/silent-login-errors/silent-login-errors.md"]
+related: ["wiki/queries/new-user-auth-flow/new-user-auth-flow.md", "wiki/features/error-boundary/error-boundary.md"]
+---
+
+# Bug: Silent login errors — no user-facing feedback on auth failure
+
+Status: **fixed**
+Severity: **medium**
+
+## Symptom
+
+Authentication failures on the login page produced **zero user feedback**. Both Google sign-in and email/password auth errors were swallowed into `console.error` only — the user saw nothing.
+
+- **Popup blocked** → Google sign-in silently does nothing (ad-blockers / strict browser privacy settings are common).
+- **Wrong email/password** → the form just does nothing.
+- **Network errors** → invisible.
+
+## Reproduction
+
+1. Open the app → Login page.
+2. Block popups → click "Sign in with Google" → nothing happens.
+3. Enter a wrong password → no error shown.
+4. Go offline and attempt login → no error, no hint.
+
+## Root Cause Analysis
+
+- `src/pages/LoginPage.tsx:28-31` — `handleSubmit` catch block for `signInWithEmailAndPassword` / `createUserWithEmailAndPassword` only called `console.error("Errore:", error.code)`. A commented-out `alert()` (line 30) marks this as known-temporary, never revisited.
+- `src/pages/LoginPage.tsx:41-43` — `handleLogin` catch block for `signInWithPopup` only did `console.error('Error logging in:', error)`. This is the worst case: a **common** failure (`auth/popup-blocked`) leaves the user thinking the app is broken.
+- The page had no Snackbar/Alert/error state, while the app already ships `AlertSnackbar` (`src/components/shared/AlertSnackbar.tsx`) used by ConfigPage.
+- No i18n for auth messages: the rest of the app uses `react-i18next` (`en.json`/`it.json`) but the login page had hardcoded strings.
+
+## Fix
+
+1. Added an **`auth` i18n section** to `src/locales/en.json` and `src/locales/it.json` mapping Firebase auth error codes to user-friendly, localized messages.
+2. Added a **`getAuthErrorMessage(error)`** helper in `LoginPage.tsx` that maps `error.code` → localized message (with a generic fallback).
+3. Added **`alertState` + `showAlert()` + `<AlertSnackbar/>`** to `LoginPage.tsx`, wired into both catch blocks.
+4. Used `useTranslation()` for all messages.
+
+Error codes handled: `auth/popup-blocked`, `auth/wrong-password`, `auth/user-not-found`, `auth/invalid-credential`, `auth/invalid-email`, `auth/email-already-in-use`, `auth/weak-password`, `auth/network-request-failed`, `auth/too-many-requests`, `auth/user-disabled`, `auth/operation-not-allowed`, `auth/popup-closed-by-user`, `auth/cancelled-popup-request`, plus a generic fallback.
+
+## Related
+
+- [[wiki/queries/new-user-auth-flow/new-user-auth-flow]] — earlier Google auth flow analysis
+- [[wiki/features/error-boundary/error-boundary]] — related UX-resilience work
+- Source: [raw/bugs/silent-login-errors/silent-login-errors.md](raw/bugs/silent-login-errors/silent-login-errors.md)

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -383,5 +383,21 @@
     "idealBurnRate": "Ideal Burn Rate",
     "actualSpend": "Actual Spend",
     "noBurnUpData": "No spending data for this period"
+  },
+  "auth": {
+    "popupBlocked": "Google sign-in was blocked. Please allow popups for this site and try again.",
+    "popupClosedByUser": "Sign-in popup closed before completing. Please try again.",
+    "cancelledPopupRequest": "Sign-in was cancelled. Please try again.",
+    "wrongPassword": "Invalid email or password.",
+    "userNotFound": "No account found with this email.",
+    "invalidCredential": "Invalid email or password.",
+    "invalidEmail": "Please enter a valid email address.",
+    "emailAlreadyInUse": "An account with this email already exists. Try signing in instead.",
+    "weakPassword": "Password is too weak. Use at least 6 characters.",
+    "networkRequestFailed": "Network error. Check your connection and try again.",
+    "tooManyRequests": "Too many attempts. Please wait a moment and try again.",
+    "userDisabled": "This account has been disabled.",
+    "operationNotAllowed": "This sign-in method is not allowed.",
+    "genericError": "Something went wrong. Please try again."
   }
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -383,5 +383,21 @@
     "idealBurnRate": "Spesa Ideale",
     "actualSpend": "Spesa Reale",
     "noBurnUpData": "Nessun dato di spesa per questo periodo"
+  },
+  "auth": {
+    "popupBlocked": "Accesso con Google bloccato. Consenti i popup per questo sito e riprova.",
+    "popupClosedByUser": "La finestra di accesso è stata chiusa prima del completamento. Riprova.",
+    "cancelledPopupRequest": "Accesso annullato. Riprova.",
+    "wrongPassword": "Email o password non validi.",
+    "userNotFound": "Nessun account trovato con questa email.",
+    "invalidCredential": "Email o password non validi.",
+    "invalidEmail": "Inserisci un indirizzo email valido.",
+    "emailAlreadyInUse": "Esiste già un account con questa email. Prova ad accedere.",
+    "weakPassword": "Password troppo debole. Usa almeno 6 caratteri.",
+    "networkRequestFailed": "Errore di rete. Controlla la connessione e riprova.",
+    "tooManyRequests": "Troppi tentativi. Attendi un momento e riprova.",
+    "userDisabled": "Questo account è stato disabilitato.",
+    "operationNotAllowed": "Questo metodo di accesso non è consentito.",
+    "genericError": "Qualcosa è andato storto. Riprova."
   }
 }

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -2,16 +2,48 @@ import { Google as GoogleIcon } from '@mui/icons-material';
 import { Box, Button, Container, Divider, Paper, TextField, Typography } from '@mui/material';
 import { createUserWithEmailAndPassword, signInWithEmailAndPassword, signInWithPopup } from 'firebase/auth';
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Navigate } from 'react-router-dom';
 import { auth, googleProvider } from '../lib/firebase';
 import { useAuthStore } from '../store/useAuthStore';
 import BalancrLogo from '../components/BalancrLogo';
+import { AlertSnackbar } from '../components/shared/AlertSnackbar';
+
+const getAuthErrorMessage = (error: unknown, t: (key: string) => string): string => {
+  const code = (error as { code?: string })?.code;
+  const messages: Record<string, string> = {
+    'auth/popup-blocked': t('auth.popupBlocked'),
+    'auth/popup-closed-by-user': t('auth.popupClosedByUser'),
+    'auth/cancelled-popup-request': t('auth.cancelledPopupRequest'),
+    'auth/wrong-password': t('auth.wrongPassword'),
+    'auth/user-not-found': t('auth.userNotFound'),
+    'auth/invalid-credential': t('auth.invalidCredential'),
+    'auth/invalid-email': t('auth.invalidEmail'),
+    'auth/email-already-in-use': t('auth.emailAlreadyInUse'),
+    'auth/weak-password': t('auth.weakPassword'),
+    'auth/network-request-failed': t('auth.networkRequestFailed'),
+    'auth/too-many-requests': t('auth.tooManyRequests'),
+    'auth/user-disabled': t('auth.userDisabled'),
+    'auth/operation-not-allowed': t('auth.operationNotAllowed'),
+  };
+  return code ? (messages[code] ?? t('auth.genericError')) : t('auth.genericError');
+};
 
 const LoginPage: React.FC = () => {
   const { user } = useAuthStore();
+  const { t } = useTranslation();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isRegistering, setIsRegistering] = useState(false); // Stato per cambiare modalità
+  const [alertState, setAlertState] = useState<{ open: boolean; message: string; severity: 'error' | 'warning' | 'info' | 'success' }>({ open: false, message: '', severity: 'error' });
+
+  const showAlert = (message: string, severity: 'error' | 'warning' | 'info' | 'success' = 'error') => {
+    setAlertState({ open: true, message, severity });
+  };
+
+  const handleCloseAlert = () => {
+    setAlertState(prev => ({ ...prev, open: false }));
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -19,15 +51,12 @@ const LoginPage: React.FC = () => {
       if (isRegistering) {
         // REGISTRAZIONE
         await createUserWithEmailAndPassword(auth, email, password);
-        // console.log("Account creato con successo!");
       } else {
         // LOGIN
         await signInWithEmailAndPassword(auth, email, password);
       }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
-      console.error("Errore:", error.code);
-      // Esempio: alert("Errore: " + error.message);
+    } catch (error) {
+      showAlert(getAuthErrorMessage(error, t));
     }
   };
 
@@ -39,7 +68,7 @@ const LoginPage: React.FC = () => {
     try {
       await signInWithPopup(auth, googleProvider);
     } catch (error) {
-      console.error('Error logging in:', error);
+      showAlert(getAuthErrorMessage(error, t));
     }
   };
 
@@ -55,9 +84,16 @@ const LoginPage: React.FC = () => {
     }}>
       <Container maxWidth="xs">
         <Paper elevation={24} sx={{ p: 4, textAlign: 'center', borderRadius: 1, background: 'rgba(30, 41, 59, 0.8)', backdropFilter: 'blur(20px)', border: '1px solid rgba(255, 255, 255, 0.1)' }}>
-          <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
-            <BalancrLogo size={64} showText />
-          </Box>
+<AlertSnackbar
+          open={alertState.open}
+          message={alertState.message}
+          severity={alertState.severity}
+          onClose={handleCloseAlert}
+        />
+
+        <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
+          <BalancrLogo size={64} showText />
+        </Box>
           <Typography variant="body1" sx={{ mb: 4, color: 'text.secondary' }}>
             Track your finances with ease and precision.
           </Typography>


### PR DESCRIPTION
## What

Fixes #157 — authentication errors on the login page were silently caught and only console.logged. Users saw nothing on failure (popup blocked, wrong email/password, network errors).

## Changes

- **`src/pages/LoginPage.tsx`**: added `getAuthErrorMessage(error)` mapping Firebase auth error codes to localized messages, wired an `AlertSnackbar` (reusing the existing app-wide component) into both `handleSubmit` and `handleLogin` catch blocks, using `useTranslation()`.
- **`src/locales/en.json` / `it.json`**: added an `auth` section with user-friendly messages for popup-blocked, wrong password, user-not-found, invalid-credential, invalid-email, email-already-in-use, weak-password, network-request-failed, too-many-requests, user-disabled, operation-not-allowed, popup-closed/cancelled, and a generic fallback.

## Wiki

- Raw analysis: `docs/YATF/raw/bugs/silent-login-errors/`
- Bug page: `wiki/bugs/silent-login-errors` (status: fixed), indexes + log updated.

## Verification

- `npm run build` clean; `npm run lint` — no new issues in modified files (baseline errors untouched).