### PR TITLE
docs(YATF): Firestore write rate limiting threat model (#159)

### DIFF
--- a/docs/YATF/index.md
+++ b/docs/YATF/index.md
@@ -7,8 +7,8 @@ timestamp: 2026-08-03
 
 # Wiki Index
 
-*Last updated: 2026-08-06* (Account deletion feature)
-*Total pages: 72*
+*Last updated: 2026-08-06* (Firestore write rate limiting)
+*Total pages: 73*
 
 ---
 
@@ -72,6 +72,7 @@ timestamp: 2026-08-03
 | [[wiki/decisions/typescript-7-upgrade]] | ✅ TS 7.0 Go-rewrite adoption with linting workaround via `@typescript/typescript6` | [`raw/typescript-7-upgrade/`](raw/typescript-7-upgrade/) |
 | [[wiki/decisions/chart-migration-mui]] | ✅ Migrated 16 chart components from Recharts to MUI X Charts — theme-aware, phased migration | [`raw/chart-migration/`](raw/chart-migration/) |
 | [[wiki/decisions/saas-readiness]] | 🔴 **MAX PRIORITY** — Hard blockers vs ship-as-is: fix 6 critical items, launch, iterate with real users | [`raw/saas-readiness/saas-readiness.md`](raw/saas-readiness/saas-readiness.md) |
+| [[wiki/decisions/firestore-rate-limiting]] | 📋 No server-side write rate limiting; client-only app → defer App Check + server-side limiting to paid-tier launch | [`#159`](https://github.com/AlexDevsTheWeb/myfinance/issues/159) |
 | [[wiki/decisions/pwa-strategy]] | 🟢 PWA prima, Flutter dopo — mobile senza riscrittura, 2-step plan | [`raw/go-to-market/go-to-market.md`](raw/go-to-market/go-to-market.md) |
 | [[wiki/decisions/balancr-identity-system]] | ✅ Balancr identity: Linked Hexagons logo, dark palette, gradient system | [`raw/balancr-identity-system/balancr-identity-system.md`](raw/balancr-identity-system/balancr-identity-system.md) |
 

--- a/docs/YATF/log.md
+++ b/docs/YATF/log.md
@@ -681,6 +681,17 @@ description: "Chronological append-only record of all wiki operations: ingests, 
 - Updated index.md (72 pages), wiki/features/index.md
 - Cross-links: new-user-auth-flow, backup-restore-data-coverage
 
+## [2026-08-06] ingest | Decision | Firestore write rate limiting (#159)
+- User report (#159): no rate limiting or throttling on Firestore writes — `firestore.rules` checks auth only (`isSignedIn()`/`isOwner(userId)`), no read/write-count guard, no field validation. Client-only app (no backend/Cloud Functions), so all writes go directly through the SDK.
+- Impact at current scale is low; exposure grows at paid-tier launch (free-tier budget 50k reads / 20k writes per day; runaway loop or scripted REST abuse).
+- Existing defense: `isSaving`/`isCheckingRecurring` guards in all stores + 5s `checkRecurring` throttle (prevents overlap, not runaway sequential writes).
+- Key finding: Firestore rules have no time-based primitives; the often-suggested `request.write_requests_per_minute` is not a real rules API → rules-based counters not viable.
+- Created [[raw/159-rate-limiting/159-rate-limiting.md]] — full threat model + mitigation matrix
+- Created [[wiki/decisions/firestore-rate-limiting]] — decision page (status: accepted)
+- Decision: document now, defer App Check + server-side limiting to paid-tier launch (track with [[wiki/plans/go-to-market]]); cheap client-side write-guard applied to bulk-write paths can be done pre-launch
+- Updated index.md (73 pages), wiki/decisions/index.md
+- Cross-links: saas-readiness, go-to-market, concerns-and-tech-debt, external-integrations
+
 ## [2026-08-06] implement | Feature | Account deletion (#158)
 - Added `src/lib/deleteAccount.ts` — `deleteUserAccount()`: reauthenticates via provider (Google popup / email-password credential), bulk-deletes transactions + portfolio_history subcollections, deletes `users/{uid}`, calls `deleteUser()`
 - ConfigPage General tab: danger-zone "Delete Account" section with typed-email confirmation dialog, loading state, AlertSnackbar success/error feedback

--- a/docs/YATF/raw/159-rate-limiting/159-rate-limiting.md
+++ b/docs/YATF/raw/159-rate-limiting/159-rate-limiting.md
@@ -1,0 +1,96 @@
+# Threat Model — No Firestore write rate limiting (#159)
+
+**Status:** DOCUMENTED (analyzed 2026-08-06; implementation deferred to SaaS launch)
+**Severity:** low–medium
+**Related issue:** [#159](https://github.com/AlexDevsTheWeb/myfinance/issues/159)
+**Related decisions:** [saas-readiness](../../saas-readiness/saas-readiness.md), [go-to-market](../../go-to-market/go-to-market.md)
+**Related architecture:** [external-integrations](../codebase/INTEGRATIONS.md), [concerns-and-tech-debt](../codebase/CONCERNS.md)
+
+---
+
+## Summary
+
+There is no rate limiting or throttling on Firestore writes. An authenticated user can write an unlimited number of documents in rapid succession. `firestore.rules` checks **auth only** (`isSignedIn()` / `isOwner(userId)`) — no rate, no write-count guard, no field validation. All client-side writes go directly to Firestore through `firebase/firestore` with no server-side layer in between.
+
+**Impact at current scale (low):** personal/small-scale use makes this a theoretical risk today. The realistic exposure is (a) the Firestore free tier limits (50k reads/day, 20k writes/day) being exhausted by one user or a runaway loop, and (b) no guard against accidental runaway writes (e.g., a buggy loop in `checkRecurring`).
+
+## Current Defense-in-Depth State
+
+| Layer | Status | Evidence |
+|-------|--------|----------|
+| Auth check in rules | ✅ Present | `firestore.rules` `isSignedIn()` + `isOwner(userId)` on all `users/{userId}` docs and subcollections |
+| Rate limit in rules | ❌ Absent | No `request.write_requests_per_minute` (not a real Firestore rules feature), no counters, no time windows |
+| Server-side proxy/backend | ❌ Absent | Pure client app; no Cloud Functions, no custom backend |
+| Firebase App Check | ❌ Absent | `src/lib/firebase.ts` only initializes app + auth + firestore; no `getAppCheck`/`ReCaptchaV3Provider` |
+| Client-side `isSaving` guard | ✅ Present | All stores (`useFinanceStore`, `useInvestmentStore`, `useBudgetStore`, `sync/index.ts`) set `isSaving` around each write action, preventing concurrent double-writes from the UI |
+| Client-side throttle | ⚠️ Partial | `checkRecurring` has a 5s `lastRecurringCheck` guard (`useFinanceStore.ts:819-822`) + `isCheckingRecurring` re-entrancy lock |
+| Client-side debounce of rapid-fire UI actions | ⚠️ Partial | `isSaving` blocks overlap but does not rate-limit *sequential* rapid writes (e.g., rapid-fire import or a tight loop calling a save action) |
+| Field-level validation in rules | ❌ Absent | Rules do not validate doc structure or types (see CONCERNS.md) |
+
+## Threat Scenarios
+
+1. **Single-user quota exhaustion:** a user (or attacker with a valid account) writes thousands of documents rapidly → consumes the project-wide free-tier 20k writes/day → degrades service for all users.
+2. **Runaway client loop:** a regression in `checkRecurring` (see #146 duplicate bug) or in a bulk-write action (import, restore, backup) could fire unbounded writes. The 5s throttle is the only current guard and is specific to one action.
+3. **Scripted abuse at SaaS launch:** once the app is paid/multi-tenant at scale, an attacker can bypass the UI entirely and drive the Firestore REST API with their own auth token — client-side throttling cannot stop this, only server-side controls can.
+
+## Key Constraint: Client-Only App
+
+There is **no backend** in this project. Client-side throttle/debounce protects against accidental runaway writes but is trivially bypassable by anyone scripting the Firestore API directly. Real abuse prevention at scale requires one of:
+
+1. **Firebase App Check** (recommended primary) — proves each request comes from the legitimate app. Web implementation uses a reCAPTCHA site key (`ReCaptchaV3Provider`). Blocks calls not issued by the deployed app, including the Firestore REST API. Requires: Firebase console setup (App Check + reCAPTCHA Enterprise key) and a `VITE_*` env var for the site key.
+2. **Server-side rate limiting** — Cloud Functions or a custom backend that tracks writes per user per window. The proper long-term solution for paid-tier scale, but substantial infrastructure.
+3. **Firestore rules counters** — not viable: Firestore rules have no time-based primitives; implementing per-user counters in rules is fragile and bypassable, and the issue's suggestion of `request.write_requests_per_minute` is not a real rules API. Recorded here so it is not re-investigated.
+
+## Recommended Mitigations (in priority order)
+
+### At SaaS launch (server-side, real protection)
+
+1. **Firebase App Check (Web)** — add to `src/lib/firebase.ts`:
+   ```ts
+   import { initializeAppCheck, ReCaptchaV3Provider } from "firebase/app-check";
+   const appCheck = initializeAppCheck(app, {
+     provider: new ReCaptchaV3Provider(siteKey),
+     isTokenAutoRefreshEnabled: true,
+   });
+   ```
+   - Site key from env var (`VITE_FIREBASE_APPCHECK_SITE_KEY`), **conditional init** so the app keeps working in dev/CI when the key is absent.
+   - Enforce in Firebase console (Firestore enforcement) once enabled.
+   - Note: App Check on web ships with the reCAPTCHA site key in the client bundle — it raises the bar (blocks non-app calls) but does not stop someone extracting the key; pair with server-side limiting for hard guarantees.
+2. **Server-side rate limiting (Cloud Functions)** — per-user write counter with sliding window; reject/backoff beyond a threshold. Real enforcement for a paid tier.
+
+### Client-side hardening (cheap, do now or before launch)
+
+3. **Shared write-throttle guard** — a small util (e.g., `src/lib/writeGuard.ts`) wrapping Firestore write calls with a per-user minimum interval + max-burst counter. Apply to bulk-write paths: `importAllData`, backup/restore, and the `checkRecurring` transaction-generation loop. This complements the existing `isSaving` flags (which prevent overlap, not runaway sequential loops).
+4. **Keep `isSaving` + `isCheckingRecurring` guards** (already present) — they are the correct first line for UI-driven writes.
+
+## Decision
+
+**Document the threat model now; defer implementation to the paid-tier launch** (track with saas-readiness / go-to-market plans). Rationale:
+
+- At current personal/small-scale usage, exposure is low and no incident has occurred.
+- Client-side throttling alone is bypassable and adds risk of introducing bugs into hot write paths (the codebase already has known concurrency concerns in the single-doc write model).
+- App Check + server-side limiting are the correct fixes and belong together with the launch work that introduces real multi-tenant exposure.
+- The cheap client-side hardening (item 3 above) can be done opportunistically before launch without a full backend.
+
+## Files That Would Change When Implemented
+
+- `src/lib/firebase.ts` — conditional App Check init
+- `.env` / `.env.*` — `VITE_FIREBASE_APPCHECK_SITE_KEY`
+- `firestore.rules` — field-level validation (optional hardening, separate concern)
+- New `src/lib/writeGuard.ts` — shared throttle util
+- `src/store/useFinanceStore.ts` (bulk write paths), `src/store/sync/index.ts` — apply guard
+
+## Verification
+
+- No code changes in this pass (documentation-only).
+- OKF check passes: `python3 docs/YATF/scripts/okf_migrate.py --check`.
+- Wiki: raw analysis + `wiki/decisions/firestore-rate-limiting` decision page, indexes and log updated.
+
+## Related
+
+- [saas-readiness](../../saas-readiness/saas-readiness.md) — launch-blocking decision matrix
+- [go-to-market](../../go-to-market/go-to-market.md) — launch plan with data-security phase
+- [concerns-and-tech-debt](../codebase/CONCERNS.md) — Firestore write pattern + rules validation concerns
+- [external-integrations](../codebase/INTEGRATIONS.md) — Firebase config / env management
+- `src/store/useFinanceStore.ts` — `isSaving` / `isCheckingRecurring` / 5s throttle
+- `firestore.rules` — current auth-only rules

--- a/docs/YATF/wiki/decisions/firestore-rate-limiting.md
+++ b/docs/YATF/wiki/decisions/firestore-rate-limiting.md
@@ -1,0 +1,51 @@
+---
+type: Decision
+title: "Firestore write rate limiting"
+description: "No server-side write rate limiting exists; client-only app means client throttle is bypassable — defer App Check + server-side limiting to paid-tier launch."
+resource: "https://github.com/AlexDevsTheWeb/myfinance/issues/159"
+tags: [decision, security, firestore, rate-limiting]
+created: 2026-08-06
+updated: 2026-08-06
+status: accepted
+sources: ["raw/159-rate-limiting/159-rate-limiting.md"]
+related:
+  - "wiki/decisions/saas-readiness.md"
+  - "wiki/architecture/concerns-and-tech-debt.md"
+  - "wiki/architecture/external-integrations.md"
+---
+
+# Decision: Firestore Write Rate Limiting
+
+Status: accepted
+Severity: low–medium
+
+## Context
+
+`firestore.rules` only checks auth (`isSignedIn()` / `isOwner(userId)`). An authenticated user can write an unlimited number of documents in rapid succession — no rate guard, no counters, no field validation. The app is **client-only** (no backend, no Cloud Functions), so all writes go directly through the SDK.
+
+Impact today is low (personal/small-scale). Exposure grows at paid-tier launch: one user or a runaway loop could exhaust the Firestore free-tier budget (50k reads / 20k writes per day).
+
+## Options Considered
+
+1. **Firebase App Check (Web)** — prove each request comes from the legitimate app via `ReCaptchaV3Provider` + a reCAPTCHA site key. Real abuse prevention; blocks direct REST API abuse. Requires Firebase console setup + a new env var; ships the site key in the client bundle (raises the bar, not a hard guarantee).
+2. **Server-side rate limiting (Cloud Functions)** — per-user write counter with sliding window; real enforcement but substantial new infrastructure.
+3. **Firestore rules counters** — not viable. Firestore rules have no time-based primitives; the often-suggested `request.write_requests_per_minute` is not a real rules API. Fragile and bypassable.
+4. **Client-side throttle/debounce** — cheap, protects against accidental runaway loops, but trivially bypassed by scripting the Firestore API directly.
+
+## Decision
+
+**Document the threat model now; defer implementation to the paid-tier launch.** Client-side hardening alone is bypassable and would add risk to already-hot write paths; the correct fix (App Check + server-side limiting) belongs with the launch work that introduces real multi-tenant exposure. Track with the [[wiki/plans/go-to-market]] data-security phase.
+
+## Consequences
+
+- Current mitigations stay as-is: `isSaving` / `isCheckingRecurring` guards + the 5s `checkRecurring` throttle.
+- Before launch: add conditional App Check init in `src/lib/firebase.ts` (env-gated `VITE_FIREBASE_APPCHECK_SITE_KEY`) and a shared `src/lib/writeGuard.ts` throttle applied to bulk-write paths (import, restore, backup, `checkRecurring`).
+- The issue's rules-based suggestions (`request.write_requests_per_minute`) are documented as non-real so they are not re-investigated.
+
+## Related
+
+- [[wiki/decisions/saas-readiness]]
+- [[wiki/plans/go-to-market]]
+- [[wiki/architecture/concerns-and-tech-debt]]
+- [[wiki/architecture/external-integrations]]
+- Source: [raw/159-rate-limiting](raw/159-rate-limiting/159-rate-limiting.md)

--- a/docs/YATF/wiki/decisions/index.md
+++ b/docs/YATF/wiki/decisions/index.md
@@ -15,6 +15,7 @@ Architecture Decision Records (ADRs) and trade-off analyses.
 |---------|-------------|
 | [[decisions/balancr-identity-system|balancr-identity-system]] | Balancr visual identity: Linked Hexagons logo, dark palette, and gradient system. |
 | [[decisions/chart-migration-mui|chart-migration-mui]] | Migration of 16 chart components from Recharts to MUI X Charts for theme-awareness. |
+| [[decisions/firestore-rate-limiting|firestore-rate-limiting]] | No server-side write rate limiting; client-only app → defer App Check + server-side limiting to paid-tier launch. |
 | [[decisions/pwa-strategy|pwa-strategy]] | PWA-first mobile strategy before Flutter — mobile support without a full rewrite. |
 | [[decisions/saas-readiness|saas-readiness]] | Hard blockers vs ship-as-is analysis: fix 6 critical items, launch, iterate with real users. |
 | [[decisions/typescript-7-upgrade|typescript-7-upgrade]] | TypeScript 7.0 Go-rewrite adoption with ESLint linting workaround via @typescript/typescript6. |


### PR DESCRIPTION
## What
Documentation-only resolution of issue #159 — no code changes.

## Changes
- **Raw analysis:** `docs/YATF/raw/159-rate-limiting/159-rate-limiting.md` — full threat model + defense-in-depth matrix + mitigation priorities.
- **Decision page:** `docs/YATF/wiki/decisions/firestore-rate-limiting.md` (status: accepted).
- Updated `index.md` (→73 pages), `wiki/decisions/index.md`, `log.md`.
- Posted analysis comment on #159 (https://github.com/AlexDevsTheWeb/myfinance/issues/159#issuecomment-5202688934).

## Key conclusion
Rules-based rate limiting (`request.write_requests_per_minute`) is not viable (not a real Firestore rules API). Correct fix = Firebase App Check + server-side Cloud Functions limiting, deferred to paid-tier launch. Existing `isSaving`/5s-throttle guards remain the client-side stopgap.

## Verify
- OKF check passes.
- Documentation only — run `npm run build` / `npm run lint` unaffected.