### PR TITLE
fix(store): persist category rename/remap to transactions subcollection (#56)

### DIFF
--- a/docs/YATF/index.md
+++ b/docs/YATF/index.md
@@ -7,8 +7,8 @@ timestamp: 2026-08-03
 
 # Wiki Index
 
-*Last updated: 2026-08-06* (Firestore write rate limiting)
-*Total pages: 73*
+*Last updated: 2026-08-06* (Legacy transactions[] write-back)
+*Total pages: 74*
 
 ---
 
@@ -96,6 +96,7 @@ timestamp: 2026-08-03
 | [[wiki/bugs/broker-transaction-filter]] | ✅ Broker filter shows 0 invested / no holdings — manual ETF transactions never persisted `brokerId` — **fixed** | [`raw/bugs/broker-transaction-filter/broker-transaction-filter.md`](raw/bugs/broker-transaction-filter/broker-transaction-filter.md) |
 | [[wiki/bugs/etf-pricing-total-return]] | ✅ Total Return stuck at €0 — price provider dead (yfin.dev); switched to Yahoo with Xetra-first resolution + SWDA→EUNL consolidation — **fixed** | [`raw/bugs/etf-pricing-total-return/etf-pricing-total-return.md`](raw/bugs/etf-pricing-total-return/etf-pricing-total-return.md) |
 | [[wiki/bugs/silent-login-errors]] | ✅ Auth failures (popup blocked, wrong password, network) silently swallowed — now localized AlertSnackbar feedback — **fixed** | [`#157`](https://github.com/AlexDevsTheWeb/myfinance/issues/157) |
+| [[wiki/bugs/transactions-array-write-back]] | ✅ 5 actions re-wrote full transactions array to dead main-doc field (1 MiB risk + lost renames) — now persisted to subcollection — **fixed** | [`#56`](https://github.com/AlexDevsTheWeb/myfinance/issues/56) |
 
 ## Architecture
 

--- a/docs/YATF/log.md
+++ b/docs/YATF/log.md
@@ -681,6 +681,18 @@ description: "Chronological append-only record of all wiki operations: ingests, 
 - Updated index.md (72 pages), wiki/features/index.md
 - Cross-links: new-user-auth-flow, backup-restore-data-coverage
 
+## [2026-08-06] ingest | Bug | Legacy transactions[] write-back to main user doc (#56)
+- Re-validated issue #56 (Scaling limits). Concern 1 (1 MiB doc): transactions already subcollected, but found a regression — 5 actions (`_migrateToMultiAccount`, `renameCategory`, `renameSubcategory`, `deleteSubcategoryAndRemap`, `moveSubcategory`) still wrote the full transactions array to the dead `transactions` field on `users/{uid}`. Bloat risk + renames never reached the subcollection (silently reverted on reload).
+- Created [[raw/scaling-limits-review/scaling-limits-review.md]] — full 3-concern validity check
+- Created [[wiki/bugs/transactions-array-write-back]] — bug page (status: fixed)
+- Updated index.md (74 pages), wiki/bugs/index.md
+- Cross-links: firestore-rate-limiting, concerns-and-tech-debt
+
+## [2026-08-06] fix | Bug | Legacy transactions[] write-back (#56)
+- Added `persistTransactionsToSubcollection()` helper (writeBatch, 400-op chunks) in `src/store/useFinanceStore.ts`
+- Fixed 5 sites to persist only `changedTransactions` to the subcollection; main-doc `updateDoc` keeps only categories/recurringTransactions
+- Verified: `npm run build` clean; `npm run lint` no new issues; grep confirms no remaining `transactions:` write to main doc
+
 ## [2026-08-06] ingest | Decision | Firestore write rate limiting (#159)
 - User report (#159): no rate limiting or throttling on Firestore writes — `firestore.rules` checks auth only (`isSignedIn()`/`isOwner(userId)`), no read/write-count guard, no field validation. Client-only app (no backend/Cloud Functions), so all writes go directly through the SDK.
 - Impact at current scale is low; exposure grows at paid-tier launch (free-tier budget 50k reads / 20k writes per day; runaway loop or scripted REST abuse).

--- a/docs/YATF/raw/scaling-limits-review/scaling-limits-review.md
+++ b/docs/YATF/raw/scaling-limits-review/scaling-limits-review.md
@@ -1,0 +1,69 @@
+# Scaling Limits Review — Issue #56 Validity Check + transactions[] write-back regression fix
+
+**Status:** ANALYZED + PARTIALLY FIXED (2026-08-06)
+**Related issue:** [#56](https://github.com/AlexDevsTheWeb/myfinance/issues/56)
+**Related decisions:** [firestore-rate-limiting](../../wiki/decisions/firestore-rate-limiting.md), [saas-readiness](../saas-readiness/saas-readiness.md)
+**Related concerns:** [CONCERNS.md](../codebase/CONCERNS.md)
+
+---
+
+## Summary
+
+Re-validated issue #56 "[SCALING] Scaling limits" against the current codebase. The issue has 3 sub-concerns. A **new regression** was found inside concern 1: several store actions still write the full `transactions` array back to the legacy `transactions` field on the main `users/{uid}` doc — dead data that re-bloats the doc toward the 1 MiB Firestore limit and never reaches the subcollection.
+
+## Concern-by-concern validity
+
+### 1. Firestore 1 MiB document limit — PARTIALLY ADDRESSED (+ regression now fixed)
+
+**Already migrated (good):**
+- Transactions → `users/{uid}/transactions` subcollection. Rules: `firestore.rules:34-38`; refs in `src/lib/converters.ts:61-67`; idempotent backfill `backfillTransactionsToSubCollection()` in `src/store/sync/index.ts:56-100`.
+- `portfolio_history` → subcollection with server-side pagination `limit(365)` (`src/store/useInvestmentStore.ts:405-407`).
+- Reads of transactions now come exclusively from the subcollection (`onSnapshot(txnsRef)` in `src/hooks/useSyncFinance.ts:79-115`). `UserDoc` (`src/lib/converters.ts:80-104`) no longer has a `transactions` field.
+
+**Regression (fixed in this pass):**
+- 5 actions still did `updateDoc(docRef, { ..., transactions: <full array>, ... })`:
+  - `_migrateToMultiAccount` (`useFinanceStore.ts:471`)
+  - `renameCategory` (`:530`)
+  - `renameSubcategory` (`:620`)
+  - `deleteSubcategoryAndRemap` (`:691`)
+  - `moveSubcategory` (`:744`)
+- Impact: re-creates the bloated `transactions[]` array field in the main user doc (1 MiB limit risk, write amplification) AND the rename/move/remap never reached the subcollection — so renames would be silently lost on reload.
+- **Fix:** each action now computes only the `changedTransactions` (the subset matching the rename/remap predicate) and persists them to the subcollection via a new module-level helper `persistTransactionsToSubcollection()` (`writeBatch`, chunked at 400 ops). The main-doc `updateDoc` no longer includes `transactions`.
+
+**Still open for concern 1:**
+- Unbounded arrays still on the main doc: `recurringTransactions[]`, `categories[]`, `carMileage[]`, `budgetTargets[]`.
+- No server-side pagination for transactions (`onSnapshot` loads all docs; client-side `.slice()` only).
+
+### 2. In-memory state — STILL VALID
+
+- All transactional data loaded fully into Zustand (`useSyncFinance.ts:79-115` `setAll({ transactions: deduped })`).
+- `TransactionsPage.tsx:108-111` uses client-side `slice()` only; `TransactionTable.tsx:74-133` plain MUI table, no virtualization.
+- No lazy loading / infinite scroll anywhere.
+
+### 3. No offline support — STILL VALID
+
+- No service worker / PWA plugin (`vite.config.ts` plugins = `[react()]` only).
+- No Firestore offline persistence (`src/lib/firebase.ts:26` `getFirestore(app)` bare).
+- `site.webmanifest` exists but no `sw.js`; `pwa-strategy` decision documented, unimplemented.
+
+## Issue #56 overall status
+
+- **Concern 1:** largely addressed (transactions subcollected) — remaining risk is non-transaction arrays + missing pagination.
+- **Concern 2 & 3:** still open.
+- **Verdict:** issue stays open; the worst case (1 MiB transactions array regression) is now fixed.
+
+## Files Modified
+
+- `src/store/useFinanceStore.ts` — `persistTransactionsToSubcollection()` helper + fixed `_migrateToMultiAccount`, `renameCategory`, `renameSubcategory`, `deleteSubcategoryAndRemap`, `moveSubcategory`.
+
+## Verification
+
+- `npm run build` clean.
+- `npm run lint` — no new issues (same pre-existing 19 problems before/after).
+- OKF check passes.
+
+## Related
+
+- `wiki/decisions/firestore-rate-limiting.md` — sibling scaling/abuse analysis
+- `wiki/plans/go-to-market.md` — launch track for remaining scale work
+- `wiki/architecture/concerns-and-tech-debt.md` — Firestore write pattern / rules validation notes

--- a/docs/YATF/wiki/bugs/index.md
+++ b/docs/YATF/wiki/bugs/index.md
@@ -22,3 +22,4 @@ Bug analysis pages: symptoms, root cause, reproduction steps, and fixes.
 | [[bugs/broker-transaction-filter|broker-transaction-filter]] | Broker filter shows 0 invested / no holdings because manual ETF transactions never persisted a brokerId — fixed. |
 | [[bugs/etf-pricing-total-return|etf-pricing-total-return]] | Total Return stuck at €0 — price provider dead (api.yfin.dev); switched to Yahoo Finance with Xetra-first venue resolution and SWDA→EUNL consolidation — fixed. |
 | [[bugs/silent-login-errors|silent-login-errors]] | Login auth failures (popup blocked, wrong password, network) silently console.logged — no user feedback. Fixed with localized AlertSnackbar messages (#157) — fixed. |
+| [[bugs/transactions-array-write-back|transactions-array-write-back]] | 5 store actions re-wrote the full transactions array to the dead main-doc field — 1 MiB bloat + renames lost on reload. Fixed by persisting changed transactions to the subcollection — fixed. |

--- a/docs/YATF/wiki/bugs/transactions-array-write-back.md
+++ b/docs/YATF/wiki/bugs/transactions-array-write-back.md
@@ -1,0 +1,62 @@
+---
+type: Bug
+title: "Legacy transactions[] written back to main user doc"
+description: "5 store actions re-wrote the full transactions array to the dead transactions field on users/{uid} — re-bloating toward 1 MiB and losing renames on reload. Fixed by persisting changed transactions to the subcollection."
+resource: "https://github.com/AlexDevsTheWeb/myfinance/issues/56"
+tags: [bug, scaling, firestore, transactions]
+created: 2026-08-06
+updated: 2026-08-06
+status: fixed
+severity: major
+sources: ["raw/scaling-limits-review/scaling-limits-review.md"]
+related:
+  - "wiki/decisions/firestore-rate-limiting.md"
+  - "wiki/architecture/concerns-and-tech-debt.md"
+---
+
+# Bug: Legacy transactions[] written back to main user doc
+
+Status: fixed
+Severity: major
+
+## Symptom
+
+After transactions were migrated to the `users/{uid}/transactions` subcollection, five store actions still wrote the **full transactions array** back to the legacy `transactions` field on the main `users/{uid}` doc:
+
+- `_migrateToMultiAccount`
+- `renameCategory`
+- `renameSubcategory`
+- `deleteSubcategoryAndRemap`
+- `moveSubcategory`
+
+Consequences:
+1. **Doc bloat** — the dead `transactions[]` array re-appeared in the main doc, risking the 1 MiB Firestore document limit (write amplification on every rename/move).
+2. **Lost renames** — reads now come only from the subcollection (`onSnapshot` in `useSyncFinance.ts`), so the rename/remap never persisted anywhere real and silently reverted on reload.
+
+## Reproduction
+
+1. Open Config → rename a category that has transactions.
+2. Reload the app — the renamed category reverts to the old name (because the subcollection docs were never updated).
+3. Inspect Firestore `users/{uid}` — the `transactions` array field exists again with every transaction.
+
+## Root Cause Analysis
+
+The subcollection migration updated transaction **reads** (`onSnapshot(txnsRef)`, `UserDoc` dropped `transactions`), but four rename/remap actions and the migration helper still used the legacy persistence path: `updateDoc(docRef, { transactions: <full array> })`. That both re-created the bloated field and bypassed the subcollection entirely.
+
+## Fix
+
+- Added module-level helper `persistTransactionsToSubcollection(userId, transactions)` in `src/store/useFinanceStore.ts` — writes the given transactions to the subcollection via `writeBatch`, chunked at 400 ops/batch.
+- Each affected action now computes only the **changed** transactions (matching its rename/remap predicate) and persists them to the subcollection; the main-doc `updateDoc` writes only the still-valid fields (`categories` / `recurringTransactions`).
+- `_migrateToMultiAccount` persists only the transactions it changed (those missing `accountId`).
+
+## Verification
+
+- `npm run build` clean.
+- `npm run lint` — no new issues (same pre-existing 19 problems before/after).
+- No remaining `transactions:` write to the main doc (grep-verified).
+
+## Related
+
+- [[wiki/decisions/firestore-rate-limiting]]
+- [[wiki/architecture/concerns-and-tech-debt]]
+- Source: [raw/scaling-limits-review](raw/scaling-limits-review/scaling-limits-review.md)

--- a/src/store/useFinanceStore.ts
+++ b/src/store/useFinanceStore.ts
@@ -37,6 +37,25 @@ export const validateRecurringTransaction = Validation.validateRecurringTransact
 // Re-export sanitization functions from sanitization folder
 export { Sanitization };
 
+async function persistTransactionsToSubcollection(userId: string, transactions: Transaction[]) {
+  if (transactions.length === 0) return;
+  const collRef = getTransactionsCollectionRef(userId);
+  let batch = writeBatch(db);
+  let count = 0;
+  for (const txn of transactions) {
+    batch.set(doc(collRef, txn.id), Sanitization.sanitizeTransaction(txn));
+    count++;
+    if (count === 400) {
+      await batch.commit();
+      batch = writeBatch(db);
+      count = 0;
+    }
+  }
+  if (count > 0) {
+    await batch.commit();
+  }
+}
+
 interface FinanceState {
   initialBalance: number;
   categories: Category[];
@@ -444,6 +463,10 @@ setBalanceStartDate: async (date) => {
         const defaultAccount = state.accounts.find(a => a.isDefault) || state.accounts[0];
         if (!defaultAccount) return;
 
+        const changedTransactions = state.transactions
+          .filter(t => !t.accountId)
+          .map(t => ({ ...t, accountId: defaultAccount.id }));
+
         set((state) => {
           const updatedTransactions = state.transactions.map(t =>
             t.accountId ? t : { ...t, accountId: defaultAccount.id }
@@ -464,13 +487,11 @@ setBalanceStartDate: async (date) => {
         set({ saveError: null, isSaving: true });
         try {
           const docRef = doc(db, 'users', userId);
-          const currentTransactions = useFinanceStore.getState().transactions;
           const currentRecurring = useFinanceStore.getState().recurringTransactions;
-          
           await updateDoc(docRef, {
-            transactions: currentTransactions,
             recurringTransactions: currentRecurring
           });
+          await persistTransactionsToSubcollection(userId, changedTransactions);
           set({ isSaving: false });
         } catch (err) {
           const errorMessage = err instanceof Error ? err.message : 'Failed to migrate to multi-account';
@@ -503,8 +524,12 @@ setBalanceStartDate: async (date) => {
 
         set({ saveError: null, isSaving: true });
         try {
+          const key = type === 'income' ? 'incomeCategories' : 'categories';
+          const changedTransactions = useFinanceStore.getState().transactions
+            .filter(t => t.type === type && t.category === oldName)
+            .map(t => ({ ...t, category: newName }));
+
           set((state) => {
-            const key = type === 'income' ? 'incomeCategories' : 'categories';
             const updatedTransactions = state.transactions.map(t =>
               t.type === type && t.category === oldName ? { ...t, category: newName } : t
             );
@@ -521,15 +546,13 @@ setBalanceStartDate: async (date) => {
             };
           });
           const docRef = doc(db, 'users', userId);
-          const key = type === 'income' ? 'incomeCategories' : 'categories';
           const categories = useFinanceStore.getState()[key as 'incomeCategories' | 'categories'];
-          const transactions = useFinanceStore.getState().transactions;
           const recurringTransactions = useFinanceStore.getState().recurringTransactions;
           await updateDoc(docRef, {
             [key]: categories,
-            transactions: transactions,
             recurringTransactions: recurringTransactions
           });
+          await persistTransactionsToSubcollection(userId, changedTransactions);
         } catch (err) {
           const errorMessage = err instanceof Error ? err.message : 'Failed to rename category';
           set({ saveError: errorMessage, isSaving: false });
@@ -590,6 +613,11 @@ setBalanceStartDate: async (date) => {
 
         set({ saveError: null, isSaving: true });
         try {
+          const key = type === 'income' ? 'incomeCategories' : 'categories';
+          const changedTransactions = useFinanceStore.getState().transactions
+            .filter(t => t.type === type && t.category === categoryName && t.subcategory === oldName)
+            .map(t => ({ ...t, subcategory: newName }));
+
           set((state) => {
             const key = type === 'income' ? 'incomeCategories' : 'categories';
             const updatedTransactions = state.transactions.map(t =>
@@ -611,15 +639,13 @@ setBalanceStartDate: async (date) => {
             };
           });
           const docRef = doc(db, 'users', userId);
-          const key = type === 'income' ? 'incomeCategories' : 'categories';
           const categories = useFinanceStore.getState()[key as 'incomeCategories' | 'categories'];
-          const transactions = useFinanceStore.getState().transactions;
           const recurringTransactions = useFinanceStore.getState().recurringTransactions;
           await updateDoc(docRef, {
             [key]: categories,
-            transactions: transactions,
             recurringTransactions: recurringTransactions
           });
+          await persistTransactionsToSubcollection(userId, changedTransactions);
         } catch (err) {
           const errorMessage = err instanceof Error ? err.message : 'Failed to rename subcategory';
           set({ saveError: errorMessage, isSaving: false });
@@ -658,6 +684,11 @@ setBalanceStartDate: async (date) => {
 
         set({ saveError: null, isSaving: true });
         try {
+          const key = type === 'income' ? 'incomeCategories' : 'categories';
+          const changedTransactions = useFinanceStore.getState().transactions
+            .filter(t => t.type === type && t.category === categoryName && t.subcategory === subToDelete)
+            .map(t => ({ ...t, subcategory: remapToSub }));
+
           set((state) => {
             const key = type === 'income' ? 'incomeCategories' : 'categories';
             const updatedTransactions = state.transactions.map(t =>
@@ -682,15 +713,13 @@ setBalanceStartDate: async (date) => {
             };
           });
           const docRef = doc(db, 'users', userId);
-          const key = type === 'income' ? 'incomeCategories' : 'categories';
           const categories = useFinanceStore.getState()[key as 'incomeCategories' | 'categories'];
-          const transactions = useFinanceStore.getState().transactions;
           const recurringTransactions = useFinanceStore.getState().recurringTransactions;
           await updateDoc(docRef, {
             [key]: categories,
-            transactions: transactions,
             recurringTransactions: recurringTransactions
           });
+          await persistTransactionsToSubcollection(userId, changedTransactions);
         } catch (err) {
           const errorMessage = err instanceof Error ? err.message : 'Failed to delete and remap subcategory';
           set({ saveError: errorMessage, isSaving: false });
@@ -704,6 +733,11 @@ setBalanceStartDate: async (date) => {
 
         set({ saveError: null, isSaving: true });
         try {
+          const key = type === 'income' ? 'incomeCategories' : 'categories';
+          const changedTransactions = useFinanceStore.getState().transactions
+            .filter(t => t.type === type && t.category === fromCategory && t.subcategory === subName)
+            .map(t => ({ ...t, category: toCategory }));
+
           set((state) => {
             if (fromCategory === toCategory) return state;
             const key = type === 'income' ? 'incomeCategories' : 'categories';
@@ -735,15 +769,13 @@ setBalanceStartDate: async (date) => {
             };
           });
           const docRef = doc(db, 'users', userId);
-          const key = type === 'income' ? 'incomeCategories' : 'categories';
           const categories = useFinanceStore.getState()[key as 'incomeCategories' | 'categories'];
-          const transactions = useFinanceStore.getState().transactions;
           const recurringTransactions = useFinanceStore.getState().recurringTransactions;
           await updateDoc(docRef, {
             [key]: categories,
-            transactions: transactions,
             recurringTransactions: recurringTransactions
           });
+          await persistTransactionsToSubcollection(userId, changedTransactions);
         } catch (err) {
           const errorMessage = err instanceof Error ? err.message : 'Failed to move subcategory';
           set({ saveError: errorMessage, isSaving: false });


### PR DESCRIPTION
## What
Re-validated issue #56 (Scaling limits) and fixed a regression found inside concern 1.

## Changes
- **Bug fix:** 5 store actions (`_migrateToMultiAccount`, `renameCategory`, `renameSubcategory`, `deleteSubcategoryAndRemap`, `moveSubcategory`) were writing the full `transactions` array back to the legacy `transactions` field on `users/{uid}` — re-bloating toward the 1 MiB document limit AND never reaching the subcollection (category renames silently reverted on reload).
- Added `persistTransactionsToSubcollection()` (writeBatch, 400-op chunks); each action now persists only its `changedTransactions` to the `transactions` subcollection. Main-doc `updateDoc` keeps only categories/recurringTransactions.
- **Wiki:** raw analysis `docs/YATF/raw/scaling-limits-review/`, bug page [[wiki/bugs/transactions-array-write-back]], indexes + log updated (→74 pages). Analysis comment posted on #56.

## Verification
- `npm run build` clean.
- `npm run lint` — no new issues (same pre-existing 19 problems before/after).
- Grep confirms no remaining `transactions:` write to the main doc.
- OKF check passes.

## Issue status
#56 stays open — concerns 2 (in-memory state) and 3 (offline) remain, plus non-transaction arrays/pagination on concern 1. Tracked in the wiki go-to-market plan.